### PR TITLE
feat/Rspec_report

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,6 @@ gem 'trix'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
 gem 'whenever', require: false
-gem 'pg', '0.20.0'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -9,4 +9,7 @@ class Report < ApplicationRecord
   attribute :resubmitted, default: false
 
   # validates :report_detail, presence: true
+  validates :title, presence: true, length: { maximum: 30 }
+  validates :report_day, presence: true
+  validates :sender_name, presence: true
 end

--- a/spec/factories/report_confirmers.rb
+++ b/spec/factories/report_confirmers.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :report_confirmer do
+    association :report
+    id { 1 }
+    report_id { 1 }
+    report_confirmer_id { 1 }
+    report_confirmation_flag { false }
+  end
+end

--- a/spec/factories/reports.rb
+++ b/spec/factories/reports.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :report do
+    association :project
+    id { 1 }
+    project_id { 1 }
+    sender_id { 1 }    
+    sender_name { 'MyText' }
+    title { 'タイトル' }
+    report_day { Date.current }
+    created_at { Date.current }
+    updated_at { Date.current }
+  end
+end

--- a/spec/models/report_confirmer_spec.rb
+++ b/spec/models/report_confirmer_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe ReportConfirmer, type: :model do
+  subject(:report_confirmer) { FactoryBot.build(:report_confirmer) }
+
+  describe '報告の確認' do   
+    context 'report_confirmer_idカラム' do
+      it '報告確認者のidがなければ登録できない' do
+        expect(build(:report_confirmer, report_confirmer_id: '')).to be_invalid
+      end      
+    end
+
+    context 'report_confirmation_flagカラム' do
+      it 'trueとfalseは登録出来る' do
+        expect(report_confirmer).to allow_value(true).for(:report_confirmation_flag)
+        expect(report_confirmer).to allow_value(false).for(:report_confirmation_flag)
+      end
+    end
+  end
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Report, type: :model do
+  subject(:report) { FactoryBot.build(:report) }
+
+  describe 'reportの登録' do   
+    context 'titleカラム' do
+      it 'titleがなければ投稿できない' do
+        expect(build(:report, title: '')).to be_invalid
+      end
+      
+      it '30文字以下であること' do
+        expect(build(:report, title: 'a' * 31)).to be_invalid
+      end
+    end
+
+    context 'report_dayカラム' do
+      it '報告日がなければ投稿できない' do
+        expect(build(:report, report_day: '')).to be_invalid
+      end
+    end
+
+    context 'sender_nameカラム' do
+      it '報告者がなければ投稿できない' do
+        expect(build(:report, sender_name: '')).to be_invalid
+      end
+    end
+  end
+end


### PR DESCRIPTION
report部分のRspecを追加します。

modified:   Gemfile
        modified:   app/models/report.rb
        new file:   spec/factories/report_confirmers.rb
        new file:   spec/factories/reports.rb
        new file:   spec/models/report_confirmer_spec.rb
        new file:   spec/models/report_spec.rb

※Gemfileは以前permissionエラーが出た時にwindows環境はポスグレ対応していないとの指導があったので追加しましたが、共通部分と本番環境のダブルに設定されることになり、結局、警告対象になる為必要がないと確認しました。