### PR TITLE
表示変更「報告状況履歴」→「報告集計」

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -18,7 +18,7 @@
         <% else %>
           <%= sidebar_link_item('今週の報告状況', user_project_reports_view_reports_path(user, project)) %>
         <% end %>
-        <%= sidebar_link_item('報告状況履歴', user_project_reports_view_reports_log_path(user, project)) %>
+        <%= sidebar_link_item('報告集計', user_project_reports_view_reports_log_path(user, project)) %>
         <%= sidebar_link_item('プロジェクト編集', edit_user_project_path(user, project)) %>
         <%= sidebar_link_item('フォーマット編集', edit_project_report_format_path(user, project)) %>
         <%= sidebar_link_item('メンバーを招待', new_invitation_path(user, project)) %>
@@ -46,7 +46,7 @@
       <% else %>
         <%= sidebar_link_item('今週の報告状況', user_project_reports_view_reports_path(user, project)) %>
       <% end %>
-      <%= sidebar_link_item('報告状況履歴', user_project_reports_view_reports_log_path(user, project)) %>
+      <%= sidebar_link_item('報告集計', user_project_reports_view_reports_log_path(user, project)) %>
       <%= sidebar_link_item('プロジェクト編集', edit_user_project_path(user, project)) %>
       <%= sidebar_link_item('フォーマット編集', edit_project_report_format_path(user, project)) %>
       <%= sidebar_link_item('メンバーを招待', new_invitation_path(user, project)) %>

--- a/app/views/projects/reports/view_reports_log.html.erb
+++ b/app/views/projects/reports/view_reports_log.html.erb
@@ -1,10 +1,10 @@
-<% provide(:title, '報告状況履歴') %>
+<% provide(:title, '報告集計') %>
 <%= content_for :side_menu do %>
   <%= render partial: 'layouts/sidebar' , locals: { user: @user, project: @project } %>
 <% end %>
 <div class="card-box">
   <p class="project-name-text">プロジェクト：<%= @project.name %></p>
-  <h1 class="text-center">報告状況履歴
+  <h1 class="text-center">報告集計
   </h1>
     <div class="card-body">
       <div class="tab-content" id="myTabContent">


### PR DESCRIPTION
### 概要
アプリ内の「報告状況履歴」の表示を「報告集計」という表示に変更。

### タスク
アプリ内の「報告状況履歴」の表示を「報告集計」という表示に変更。

### 実装内容・手法
・サイドバーの「報告状況履歴」を「報告集計」に変更。
・報告状況履歴画面のタイトルを「報告状況履歴」から「報告集計」に変更。

### 実装画像
https://docs.google.com/spreadsheets/d/1zOT0XUjAJCR4I2m70jhU5AEPWG9OqXvVIaCj5FdZmrc/edit#gid=0

### gemfileの変更
なし 
