### PR TITLE
フォーマット編集タイトル項目バリュー固定化実装（奥野）

### DIFF
--- a/app/controllers/formats/report_formats_controller.rb
+++ b/app/controllers/formats/report_formats_controller.rb
@@ -42,8 +42,6 @@ class Formats::ReportFormatsController < Formats::BaseFormatController
   def update
     # formatモデルの内容を更新する処理
     # paramsの代わりにupdate_formats_paramsが用いられているので注意
-    format_object = @project.format
-    format_object.update(title: update_formats_params[:format_attribute][@project.format.id.to_s][:title])
     params = update_formats_params[:question_attributes]
     params.each do |question_id, items|
       question_object = Question.find(question_id)
@@ -137,7 +135,6 @@ class Formats::ReportFormatsController < Formats::BaseFormatController
 
   def update_formats_params
     params.permit(
-      format_attribute: [:id, [:title]],
       question_attributes: [:id, [:id, :form_table_type, :position, :using_flag, :required, {
         text_field_attributes: %i[id label_name field_type],
         text_area_attributes: %i[id label_name field_type],

--- a/app/views/formats/report_formats/edit.html.erb
+++ b/app/views/formats/report_formats/edit.html.erb
@@ -17,7 +17,7 @@
         <div class='form'>
           <div class='label-box'>
             <p><%= format.label :title, "タイトル項目", class: 'text-right report-item-title font-weight-bold mt-3 ml-3' %></p>
-            <p class='ml-3'><%= @format.title %></p>
+            <p class='ml-3 font-weight-bold'><%= @format.title %></p>
             <%= format.label "フォームの種類:", class: 'ml-3' %>
             <%= format.label '記述式', class: 'font-weight-bold'%>
           </div>

--- a/app/views/formats/report_formats/edit.html.erb
+++ b/app/views/formats/report_formats/edit.html.erb
@@ -13,12 +13,11 @@
           <%= link_to "項目を追加", new_project_report_format_path(@user, @project), remote: true, class: "btn btn-outline-orange" %>
         </div>
       </div>
-      
         <%= f.fields_for 'format_attribute[]', @format do |format| %>
         <div class='form'>
           <div class='label-box'>
             <p><%= format.label :title, "タイトル項目", class: 'text-right report-item-title font-weight-bold mt-3 ml-3' %></p>
-            <%= format.text_field :title, class: 'ml-3 form-control' %>
+            <p class='ml-3'><%= @format.title %></p>
             <%= format.label "フォームの種類:", class: 'ml-3' %>
             <%= format.label '記述式', class: 'font-weight-bold'%>
           </div>

--- a/app/views/formats/report_formats/edit.html.erb
+++ b/app/views/formats/report_formats/edit.html.erb
@@ -13,6 +13,7 @@
           <%= link_to "項目を追加", new_project_report_format_path(@user, @project), remote: true, class: "btn btn-outline-orange" %>
         </div>
       </div>
+      
         <%= f.fields_for 'format_attribute[]', @format do |format| %>
         <div class='form'>
           <div class='label-box'>

--- a/app/views/projects/reports/_report_form.html.erb
+++ b/app/views/projects/reports/_report_form.html.erb
@@ -13,7 +13,7 @@
       </div>
     </div>
     <div class="report-form">
-      <span class="report-item-title mb-2"><%= rf.label "件名", class: "mb-0" %></span><span class="pl-2 font-weight-bold text-danger">必須</span>
+      <span class="report-item-title mb-2 font-weight-bold"><%= rf.label "件名", class: "mb-0" %></span><span class="pl-2 font-weight-bold text-danger">必須</span>
       <%= rf.text_field :title, class:'form-control form-color', placeholder: "最大30文字", maxlength: 30, required: true %>
     </div>
     <!-- div class="box-project-select">


### PR DESCRIPTION
### 概要
フォーマット編集タイトル項目バリュー固定化実装

### タスク
- [x] なし
- [ ] あり https://docs.google.com/spreadsheets/d/1qitHpAxSv65lzMyIFgvnDUr-YLbd484bAfxjEI1SDeo/edit#gid=1950435143

### 実装内容・手法
・フォーマット編集画面のタイトル項目をFormat.titleにする
・フォーマット編集でタイトル項目を変更できなくする
・プロジェクト作成時のタイトル項目のデフォルト値を[件名]にする
・報告作成画面の件名を太字にする

### 実装画像などあれば添付する
https://docs.google.com/spreadsheets/d/1Edq1n9jiJZtvCE9q3cBPbB3L-hx6lsyfxT_rIPrqw5Q/edit#gid=1137757240

### gemfileの変更
- [x] なし
- [ ] あり 
