### PR TITLE
次回報告日の変更が反映されないバグの改善（奥野）

### DIFF
--- a/app/controllers/projects/projects_controller.rb
+++ b/app/controllers/projects/projects_controller.rb
@@ -20,6 +20,7 @@ class Projects::ProjectsController < Projects::BaseProjectController
     @user = current_user
     if @user.projects.new(project_params).valid?
       @project = @user.projects.create(project_params)
+      @project.update_next_report_date(project_params[:report_frequency_selection], project_params[:week_select])
       @project.update_deadline(@project.next_report_date)
       @project.report_deadlines.create!(day: @project.next_report_date)
       @project.report_format_creation # デフォルト報告フォーマット作成アクション呼び出し
@@ -61,6 +62,7 @@ class Projects::ProjectsController < Projects::BaseProjectController
   # プロジェクト内容編集アクション
   def update
     if @project.update(project_params)
+      @project.update_next_report_date(project_params[:report_frequency_selection], project_params[:week_select])
       @project.report_deadlines.last.update(day: @project.next_report_date)
       flash[:success] = "#{@project.name}の内容を更新しました。"
     else
@@ -132,6 +134,13 @@ class Projects::ProjectsController < Projects::BaseProjectController
   private
 
   def project_params
-    params.require(:project).permit(:name, :leader_id, :report_frequency, :next_report_date, :description)
+    params.require(:project).permit(
+      :name, :leader_id,
+      :report_frequency,
+      :next_report_date,
+      :description,
+      :report_frequency_selection,
+      :week_select
+    )
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -36,6 +36,34 @@ class Project < ApplicationRecord
     end
   end
 
+  # 日数か曜日によって次回報告日を更新する
+  def update_next_report_date(report_frequency_selection, week_select)
+    if report_frequency_selection == "edit_day"
+      # 一日に一回の次回報告日は今日であるため、昨日をベースにする
+      next_report_date_calc = Date.yesterday + self.report_frequency
+      self.update(next_report_date: next_report_date_calc) unless self.next_report_date == next_report_date_calc
+    else
+      next_report_date_week_update(week_select)
+    end
+  end
+
+  def next_report_date_week_update(week_select)
+    next_report_week = Date.today.next_occurring(week_selecter[week_select])
+    self.update(next_report_date: next_sunday) unless self.next_report_date == next_report_week
+  end
+
+  def week_selecter
+    return {
+      "日" => :sunday,
+      "月" => :monday,
+      "火" => :tuesday,
+      "水" => :wednesday,
+      "木" => :thursday,
+      "金" => :friday,
+      "土" => :saturday
+    }
+  end
+
   # デフォルト報告フォーマット作成アクション(projects/projects#create内で呼ばれる)
   def report_format_creation
     text_area = TextArea.new(label_name: '報告内容')


### PR DESCRIPTION
### 概要
次回報告日の変更が反映されないバグの改善

### タスク
- [x] なし
- [x] あり (https://docs.google.com/spreadsheets/d/1qitHpAxSv65lzMyIFgvnDUr-YLbd484bAfxjEI1SDeo/edit#gid=847795939)

### 実装内容・手法
・プロジェクト登録＆更新メソッドにnext_report_dateの更新処理を追加

### 実装画像などあれば添付する
https://docs.google.com/spreadsheets/d/1Edq1n9jiJZtvCE9q3cBPbB3L-hx6lsyfxT_rIPrqw5Q/edit#gid=840549763

### gemfileの変更
- [x] なし
- [ ] あり 
