### PR TITLE
次回報告日曜日設定機能が動かないバグの改善

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -38,7 +38,7 @@ class Project < ApplicationRecord
 
   # 日数か曜日によって次回報告日を更新する
   def update_next_report_date(report_frequency_selection, week_select)
-    if report_frequency_selection == "edit_day"
+    if report_frequency_selection == "edit_day" || report_frequency_selection == "day"
       # 一日に一回の次回報告日は今日であるため、昨日をベースにする
       next_report_date_calc = Date.yesterday + self.report_frequency
       self.update(next_report_date: next_report_date_calc) unless self.next_report_date == next_report_date_calc
@@ -49,7 +49,7 @@ class Project < ApplicationRecord
 
   def next_report_date_week_update(week_select)
     next_report_week = Date.today.next_occurring(week_selecter[week_select])
-    self.update(next_report_date: next_sunday) unless self.next_report_date == next_report_week
+    self.update(next_report_date: next_report_week) unless self.next_report_date == next_report_week
   end
 
   def week_selecter


### PR DESCRIPTION
### 概要
次回報告日を曜日に切り替えて設定した際、日付の変更が反映されないバグの改善

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
・登録と更新において足りなかった条件分岐を追加
・曜日に切り替えた際のメソッドの不備を修正

### 実装画像などあれば添付する

### gemfileの変更
- [x] なし
- [ ] あり 
