### PR TITLE
機能設計No.61(プロジェクトメンバーの報告集計からの除外機能実装)(奥野)

### DIFF
--- a/app/controllers/projects/reports_controller.rb
+++ b/app/controllers/projects/reports_controller.rb
@@ -149,12 +149,13 @@ class Projects::ReportsController < Projects::BaseProjectController
     @report_days_for_each_four_weeks = four_weeks_from_yesterday_array
     # プロジェクトの情報とそのプロジェクトの報告率の値を持つ配列を代入
     @projects = Project.all.map do |project|
+      aggregated_users = Report.get_aggregated_members(project)
       @four_weeks_report_rate_array = []
       @n = 5
       # プロジェクトの一週間の報告率を４週間分のハッシュの配列として代入
       report_rate_for_each_four_weeks = @report_days_for_each_four_weeks.map do |one_week|
         @n -= 1
-        one_week_reports_rate = one_week_report_rate_calc(one_week, project)
+        one_week_reports_rate = one_week_report_rate_calc(project, one_week, aggregated_users)
         @four_weeks_report_rate_array = @four_weeks_report_rate_array.push(one_week_reports_rate)
         ["rate_week#{@n}".to_sym, "#{one_week_reports_rate}%"]
       end
@@ -295,9 +296,9 @@ class Projects::ReportsController < Projects::BaseProjectController
   end
 
   # プロジェクトメンバー全員の一週間の報告率を計算して返す
-  def one_week_report_rate_calc(one_week, project)
-    project_four_weeks_reports_size = Report.befor_deadline_reports_size(project.reports.where(report_day: one_week))
-    return (project_four_weeks_reports_size.quo(7 * project.project_users.size).to_f * 100).floor
+  def one_week_report_rate_calc(project, one_week, members)
+    project_four_weeks_reports_size = Report.befor_deadline_reports_size(Report.get_aggregated_reports(project, one_week, members))
+    return (project_four_weeks_reports_size.quo(7 * members.size).to_f * 100).floor
   end
 
   # プロジェクトメンバーかスタッフかを判断する

--- a/app/models/project_user.rb
+++ b/app/models/project_user.rb
@@ -1,4 +1,13 @@
 class ProjectUser < ApplicationRecord
   belongs_to :user
   belongs_to :project
+
+  # プロジェクトメンバーそれぞれに報告集計メンバーの除外ステータスを追加する
+  def self.member_expulsion_join(project, members)
+    project_member_expulsions = project.project_users.all
+    members.each do |member|
+      member.member_expulsion = project_member_expulsions.find(member.id).member_expulsion
+    end
+    return members
+  end
 end

--- a/app/models/project_user.rb
+++ b/app/models/project_user.rb
@@ -6,7 +6,7 @@ class ProjectUser < ApplicationRecord
   def self.member_expulsion_join(project, members)
     project_member_expulsions = project.project_users.all
     members.each do |member|
-      member.member_expulsion = project_member_expulsions.find(member.id).member_expulsion
+      member.member_expulsion = project_member_expulsions.find_by(user_id: member.id).member_expulsion
     end
     return members
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -44,6 +44,17 @@ class Report < ApplicationRecord
     joins(:answers).where('answers.value LIKE ? OR ARRAY_TO_STRING(answers.array_value, \',\') LIKE ?', "%#{keywords}%", "%#{keywords}%")
   }
 
+  # プロジェクトの報告集計対象のユーザーidを取得
+  def self.get_aggregated_members(project)
+    return project.project_users.where(member_expulsion: false).map(&:user_id)
+  end
+
+  # 報告集計対象のユーザーの任意の期間の報告を取得
+  def self.get_aggregated_reports(project, period, aggregated_members)
+    return project.reports.where(report_day: period, user_id: aggregated_members)
+  end
+
+  # 報告日までに報告したユーザーの数を取得
   def self.befor_deadline_reports_size(project_reports)
     if project_reports.present?
       return project_reports.map { |report| report.report_day == report.created_at.to_date ? report.user_id : nil }.compact.uniq.size

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   has_many :report_statuses, dependent: :destroy
 
   has_many :reports, dependent: :nullify
-  attr_accessor :remember_token, :activation_token, :reset_token, :invite_token
+  attr_accessor :remember_token, :activation_token, :reset_token, :invite_token, :member_expulsion
 
   # 招待メールを送信する
   def send_invite_email(token, name, password)
@@ -28,6 +28,7 @@ class User < ApplicationRecord
   def project_leader?
     return Project.exists?(leader_id: self.id)
   end
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -43,7 +43,11 @@
             <% if project_leader? %>
             <div class="w-50 mr-2 mb-2">
               <% unless @project.leader_id == member.id %>
-                <%= link_to "プロジェクトから外す", project_member_destroy_path(member.id, @project.id), method: :delete, data: { confirm: "#{member.name}さんをメンバーから外そうとしています。\nよろしいですか？" }, class: "btn btn-danger" %>
+                <% if member.member_expulsion %>
+                  <%= link_to "プロジェクトへ戻す", project_member_destroy_path(@user.id, @project.id, member_id: member.id), method: :delete, data: { confirm: "#{member.name}さんをメンバーへ戻そうとしています。\nよろしいですか？" }, class: "btn btn-danger" %>
+                <% else %>
+                  <%= link_to "プロジェクトから外す", project_member_destroy_path(@user.id, @project.id, member_id: member.id), method: :delete, data: { confirm: "#{member.name}さんをメンバーから外そうとしています。\nよろしいですか？" }, class: "btn btn-danger" %>
+                <% end %>
                 <% delegate = @delegates.find_by(user_from: @user.id, user_to: member.id, is_valid: true) %>
                 <% if delegate.present? %>
                   <%= link_to "リクエストをキャンセル", cancel_delegate_path(@user, @project, delegate), method: :post, class: "btn btn-danger" %>

--- a/db/migrate/20230814132005_add_colum_to_project_user.rb
+++ b/db/migrate/20230814132005_add_colum_to_project_user.rb
@@ -1,0 +1,5 @@
+class AddColumToProjectUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :project_users, :member_expulsion, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_01_034826) do
+ActiveRecord::Schema.define(version: 2023_08_14_132005) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 2022_09_01_034826) do
     t.bigint "project_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "member_expulsion", default: false, null: false
     t.index ["project_id"], name: "index_project_users_on_project_id"
     t.index ["user_id"], name: "index_project_users_on_user_id"
   end


### PR DESCRIPTION
### 概要
プロジェクトメンバーを連絡相談対応はできるようにしつつ、報告集計から除外する機能の実装

### タスク
- [ ] なし
- [x] あり https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit#gid=1075510033&range=68:68

### 実装内容・手法
・Project_memberテーブルへのメンバーの報告集計除外カラムの追加
・既存のメンバー除外機能をメンバーの報告集計除外機能へ修正
・報告集計除外とそれを戻すための画面の実装
・報告集計除外者の報告を全プロジェクト報告集計画面で集計に入れないように修正

### 実装画像などあれば添付する
https://docs.google.com/spreadsheets/d/1Edq1n9jiJZtvCE9q3cBPbB3L-hx6lsyfxT_rIPrqw5Q/edit#gid=2095922702

### gemfileの変更
- [x] なし
- [ ] あり 

### schemaの変更
- [ ] なし
- [x] あり 