### PR TITLE
報告詳細、編集画面の戻るボタン実装(奥野)

### DIFF
--- a/app/views/projects/reports/edit.html.erb
+++ b/app/views/projects/reports/edit.html.erb
@@ -47,6 +47,9 @@
             <span class="remanded-box font-weight-bold mr-2 rounded">手直しを完了する<%= f.check_box :resubmitted, {checked: ActiveRecord::Type::Boolean.new.cast(@report.resubmitted)}, checked_value = "true", unchecked_value = "false" %></span>
           <% end %>
           <%= f.submit '変更', class: "btn btn-outline-orange col-2" %>
+          <div class="text-center">
+            <%= link_to '戻る', :back, class: "btn btn-light btn-outline-secontary col-2 " %>
+          </div>
         </div>
     </div>
   <% end %>

--- a/app/views/projects/reports/show.html.erb
+++ b/app/views/projects/reports/show.html.erb
@@ -129,6 +129,9 @@ function changeForm() {
             <%= link_to "編集", edit_user_project_report_path(@user, @project, @report), class: "btn btn-light btn-outline-orange col-2" %>
           </div>
         <% end %>
+        <div class="text-center">
+          <%= link_to '戻る', user_project_reports_path(@user, @project), class: "btn btn-light btn-outline-secontary col-2 " %>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### 概要
・報告詳細＆編集画面の戻るボタンの実装
・報告編集画面遷移でエラーになりますが、報告編集画面での挙動確認はできています。

### タスク
- [ ] なし
- [x] あり ・https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit#gid=1075510033&range=88:88
・https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit#gid=1075510033&range=97:97

### 実装内容・手法
・報告詳細画面に報告履歴画面へ戻るボタンを追加
・報告編集画面に前のURLへ戻るボタンを追加

### 実装画像などあれば添付する
https://docs.google.com/spreadsheets/d/1Edq1n9jiJZtvCE9q3cBPbB3L-hx6lsyfxT_rIPrqw5Q/edit#gid=1309771726

### gemfileの変更
- [x] なし
- [ ] あり 
