### PR TITLE
連絡一覧における連絡送り先の表示修正

### DIFF
--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -13,8 +13,6 @@ class Projects::MessagesController < Projects::BaseProjectController
     you_send_message_ids = Message.where(sender_id: current_user.id).pluck(:id)
     @you_send_messages = @project.messages.where(id: you_send_message_ids).order(updated_at: 'DESC').page(params[:page]).per(5)
     set_project_and_members
-    # @recipients = @members
-    # @recipients_names = @recipients.map(&:name).join(', ')
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -13,8 +13,8 @@ class Projects::MessagesController < Projects::BaseProjectController
     you_send_message_ids = Message.where(sender_id: current_user.id).pluck(:id)
     @you_send_messages = @project.messages.where(id: you_send_message_ids).order(updated_at: 'DESC').page(params[:page]).per(5)
     set_project_and_members
-    @recipients = @members
-    @recipients_names = @recipients.map(&:name).join(', ')
+    # @recipients = @members
+    # @recipients_names = @recipients.map(&:name).join(', ')
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/app/helpers/projects/messages_helper.rb
+++ b/app/helpers/projects/messages_helper.rb
@@ -7,15 +7,15 @@ module Projects::MessagesHelper
     svg['class'] = options[:class] if options[:class].present?
     doc.to_html.html_safe
   end
-  
+
   # 連絡の送信対象者を取得
-  def get_message_recipients(message_id)
+  def get_message_recipients(message_id, members)
     recipients = MessageConfirmer.where(message_id: message_id)
     recipient_names = []
-    
+
     recipients.each do |recipient|
-      member = @members.find{|a| a[:id] == recipient.message_confirmer_id}
-      recipient_names.push(member.name) if !member.nil?      
+      member = members.find { |a| a[:id] == recipient.message_confirmer_id }
+      recipient_names.push(member.name) if !member.nil?
     end
     recipient_names.join(', ')
   end

--- a/app/helpers/projects/messages_helper.rb
+++ b/app/helpers/projects/messages_helper.rb
@@ -7,4 +7,16 @@ module Projects::MessagesHelper
     svg['class'] = options[:class] if options[:class].present?
     doc.to_html.html_safe
   end
+  
+  # 連絡の送信対象者を取得
+  def get_message_recipients(message_id)
+    recipients = MessageConfirmer.where(message_id: message_id)
+    recipient_names = []
+    
+    recipients.each do |recipient|
+      member = @members.find{|a| a[:id] == recipient.message_confirmer_id}
+      recipient_names.push(member.name) if !member.nil?      
+    end
+    recipient_names.join(', ')
+  end
 end

--- a/app/views/projects/messages/index.html.erb
+++ b/app/views/projects/messages/index.html.erb
@@ -129,7 +129,7 @@
                       <%= l(message.updated_at, format: :long) %>
                     </div>
                     <div class="message-person">                     
-                       <%= get_message_recipients(message.id) %>
+                       <%= get_message_recipients(message.id, @members) %>
                     </div>
                     <div class="message-action">
                         <%= link_to "編集", edit_user_project_message_path(current_user, @project, message), class: "btn btn-outline-orange" %>

--- a/app/views/projects/messages/index.html.erb
+++ b/app/views/projects/messages/index.html.erb
@@ -129,7 +129,7 @@
                       <%= l(message.updated_at, format: :long) %>
                     </div>
                     <div class="message-person">                     
-                       <%= @recipients_names %>
+                       <%= get_message_recipients(message.id) %>
                     </div>
                     <div class="message-action">
                         <%= link_to "編集", edit_user_project_message_path(current_user, @project, message), class: "btn btn-outline-orange" %>


### PR DESCRIPTION
### 概要
連絡一覧における連絡送り先の表示修正

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
・連絡一覧：あなたが送った連絡の送信相手の表示内容を修正
（修正前）固定で全メンバー表示
（修正後）連絡作成時に送信対象として選択したメンバーのみを表示
・ヘルパーに連絡の送信対象者取得用のメソッドを追加して対応

### 実装画像などあれば添付する
<img width="1408" alt="スクリーンショット 2023-09-22 17 53 27" src="https://github.com/SUZUKI-KOUICHIROU/ho_ren_so_app/assets/102929281/7b73d3fc-1089-40db-a936-3ce8a9aa8f04">

### gemfileの変更
- [x] なし
- [ ] あり 
