### PR TITLE
Fix/change of report day

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -12,16 +12,16 @@ class BaseController < ApplicationController
     when 'report'
       @first_question = @project.questions.first
       @report_label_name = @first_question.send(@first_question.form_table_type).label_name
-      @reports = @project.reports.where.not(user_id: @user.id).order(updated_at: 'DESC').page(params[:page]).per(5)
-      @you_reports = @project.reports.where(user_id: @user.id).order(updated_at: 'DESC').page(params[:page]).per(5)
+      @reports = @project.reports.where.not(user_id: @user.id).order(created_at: 'DESC').page(params[:page]).per(5)
+      @you_reports = @project.reports.where(user_id: @user.id).order(created_at: 'DESC').page(params[:page]).per(5)
     when 'message'
-      @messages = @project.messages.all.order(updated_at: 'DESC').page(params[:page]).per(5)
+      @messages = @project.messages.all.order(created_at: 'DESC').page(params[:page]).per(5)
       you_addressee_message_ids = MessageConfirmer.where(message_confirmer_id: @user.id).pluck(:message_id)
-      @you_addressee_messages = @project.messages.where(id: you_addressee_message_ids).order(updated_at: 'DESC').page(params[:page]).per(5)
+      @you_addressee_messages = @project.messages.where(id: you_addressee_message_ids).order(created_at: 'DESC').page(params[:page]).per(5)
     when 'counseling'
-      @counselings = @project.counselings.all.order(updated_at: 'DESC').page(params[:page]).per(5)
+      @counselings = @project.counselings.all.order(created_at: 'DESC').page(params[:page]).per(5)
       you_addressee_counseling_ids = CounselingConfirmer.where(counseling_confirmer_id: @user.id).pluck(:counseling_id)
-      @you_addressee_counselings = @project.counselings.where(id: you_addressee_counseling_ids).order(updated_at: 'DESC').page(params[:page]).per(5)
+      @you_addressee_counselings = @project.counselings.where(id: you_addressee_counseling_ids).order(created_at: 'DESC').page(params[:page]).per(5)
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -1,9 +1,9 @@
 class Projects::CounselingsController < Projects::BaseProjectController
   def index
     set_project_and_members
-    @counselings = @project.counselings.all.order(updated_at: 'DESC').page(params[:page]).per(5)
+    @counselings = @project.counselings.all.order(created_at: 'DESC').page(params[:page]).per(5)
     you_addressee_counseling_ids = CounselingConfirmer.where(counseling_confirmer_id: @user.id).pluck(:counseling_id)
-    @you_addressee_counselings = @project.counselings.where(id: you_addressee_counseling_ids).order(updated_at: 'DESC').page(params[:page]).per(5)
+    @you_addressee_counselings = @project.counselings.where(id: you_addressee_counseling_ids).order(created_at: 'DESC').page(params[:page]).per(5)
   end
 
   def show

--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -7,11 +7,11 @@ class Projects::MessagesController < Projects::BaseProjectController
     @user = User.find(params[:user_id])
     @project = Project.find(params[:project_id])
     @projects = @user.projects.all
-    @messages = @project.messages.all.order(updated_at: 'DESC').page(params[:page]).per(5)
+    @messages = @project.messages.all.order(created_at: 'DESC').page(params[:page]).per(5)
     you_addressee_message_ids = MessageConfirmer.where(message_confirmer_id: @user.id).pluck(:message_id)
-    @you_addressee_messages = @project.messages.where(id: you_addressee_message_ids).order(updated_at: 'DESC').page(params[:page]).per(5)
+    @you_addressee_messages = @project.messages.where(id: you_addressee_message_ids).order(created_at: 'DESC').page(params[:page]).per(5)
     you_send_message_ids = Message.where(sender_id: current_user.id).pluck(:id)
-    @you_send_messages = @project.messages.where(id: you_send_message_ids).order(updated_at: 'DESC').page(params[:page]).per(5)
+    @you_send_messages = @project.messages.where(id: you_send_message_ids).order(created_at: 'DESC').page(params[:page]).per(5)
     set_project_and_members
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/controllers/projects/reports_controller.rb
+++ b/app/controllers/projects/reports_controller.rb
@@ -16,9 +16,7 @@ class Projects::ReportsController < Projects::BaseProjectController
     elsif params[:report_type] == 'weekly'
       @reports = @weekly_reports.where.not(sender_id: @user.id).order(updated_at: 'DESC').page(params[:page]).per(10)
       @you_reports = @weekly_reports.where(sender_id: @user.id).order(updated_at: 'DESC').page(params[:page]).per(10)
-      { reports: @reports, you_reports: @you_reports }
-    else
-      render :index
+      { reports: @reports, you_reports: @you_reports }    
     end
     if params[:search].present? and params[:search] != ""
       @results = Report.search(report_search_params)
@@ -26,11 +24,12 @@ class Projects::ReportsController < Projects::BaseProjectController
         @report_ids = @results.pluck(:id).uniq || @results.pluck(:report_id).uniq
       else
         flash.now[:danger] = '検索結果が見つかりませんでした。'
-        render :index
+        return
       end
       @reports = @project.reports.where.not(sender_id: @user.id).where(id: @report_ids).order(updated_at: 'DESC').page(params[:page]).per(10)
       @you_reports = @project.reports.where(sender_id: @user.id).where(id: @report_ids).order(updated_at: 'DESC').page(params[:page]).per(10)
     end
+    render :index
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/app/controllers/projects/reports_controller.rb
+++ b/app/controllers/projects/reports_controller.rb
@@ -5,18 +5,18 @@ class Projects::ReportsController < Projects::BaseProjectController
     set_project_and_members
     @first_question = @project.questions.first
     @report_label_name = @first_question.send(@first_question.form_table_type).label_name
-    @reports = @project.reports.where.not(sender_id: @user.id).order(updated_at: 'DESC').page(params[:page]).per(10)
-    @you_reports = @project.reports.where(sender_id: @user.id).order(updated_at: 'DESC').page(params[:page]).per(10)
+    @reports = @project.reports.where.not(sender_id: @user.id).order(created_at: 'DESC').page(params[:page]).per(10)
+    @you_reports = @project.reports.where(sender_id: @user.id).order(created_at: 'DESC').page(params[:page]).per(10)
     @monthly_reports = Report.monthly_reports_for(@project)
     @weekly_reports = Report.weekly_reports_for(@project)
     if params[:report_type] == 'monthly'
-      @reports = @monthly_reports.where.not(sender_id: @user.id).order(updated_at: 'DESC').page(params[:page]).per(10)
-      @you_reports = @monthly_reports.where(sender_id: @user.id).order(updated_at: 'DESC').page(params[:page]).per(10)
+      @reports = @monthly_reports.where.not(sender_id: @user.id).order(created_at: 'DESC').page(params[:page]).per(10)
+      @you_reports = @monthly_reports.where(sender_id: @user.id).order(created_at: 'DESC').page(params[:page]).per(10)
       { reports: @reports, you_reports: @you_reports }
     elsif params[:report_type] == 'weekly'
-      @reports = @weekly_reports.where.not(sender_id: @user.id).order(updated_at: 'DESC').page(params[:page]).per(10)
-      @you_reports = @weekly_reports.where(sender_id: @user.id).order(updated_at: 'DESC').page(params[:page]).per(10)
-      { reports: @reports, you_reports: @you_reports }    
+      @reports = @weekly_reports.where.not(sender_id: @user.id).order(created_at: 'DESC').page(params[:page]).per(10)
+      @you_reports = @weekly_reports.where(sender_id: @user.id).order(created_at: 'DESC').page(params[:page]).per(10)
+      { reports: @reports, you_reports: @you_reports }
     end
     if params[:search].present? and params[:search] != ""
       @results = Report.search(report_search_params)
@@ -26,8 +26,8 @@ class Projects::ReportsController < Projects::BaseProjectController
         flash.now[:danger] = '検索結果が見つかりませんでした。'
         return
       end
-      @reports = @project.reports.where.not(sender_id: @user.id).where(id: @report_ids).order(updated_at: 'DESC').page(params[:page]).per(10)
-      @you_reports = @project.reports.where(sender_id: @user.id).where(id: @report_ids).order(updated_at: 'DESC').page(params[:page]).per(10)
+      @reports = @project.reports.where.not(sender_id: @user.id).where(id: @report_ids).order(created_at: 'DESC').page(params[:page]).per(10)
+      @you_reports = @project.reports.where(sender_id: @user.id).where(id: @report_ids).order(created_at: 'DESC').page(params[:page]).per(10)
     end
     render :index
   end
@@ -259,7 +259,7 @@ class Projects::ReportsController < Projects::BaseProjectController
   end
 
   def report_search_params
-    params.fetch(:search, {}).permit(:title, :updated_at, :sender_name, :keywords)
+    params.fetch(:search, {}).permit(:title, :created_at, :sender_name, :keywords)
     # fetch(:search, {})と記述することで、検索フォームに値がない場合はnilを返し、エラーが起こらなくなる
     # ここでの:searchには、フォームから送られてくるparamsの値が入っている
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -22,8 +22,8 @@ class Report < ApplicationRecord
       reports = reports.title_like(search_params[:title])
     end
 
-    if search_params[:updated_at].present?
-      reports = reports.updated_at(search_params[:updated_at])
+    if search_params[:created_at].present?
+      reports = reports.created_at(search_params[:created_at])
     end
 
     if search_params[:sender_name].present?
@@ -38,7 +38,7 @@ class Report < ApplicationRecord
   end
 
   scope :title_like, ->(title) { where('title LIKE ?', "%#{title}%") }
-  scope :updated_at, ->(updated_at) { where('updated_at BETWEEN ? AND ?', "#{updated_at} 00:00:00", "#{updated_at} 23:59:59") }
+  scope :created_at, ->(created_at) { where('created_at BETWEEN ? AND ?', "#{created_at} 00:00:00", "#{created_at} 23:59:59") }
   scope :sender_name_like, ->(sender_name) { where('sender_name LIKE ?', "%#{sender_name}%") }
   scope :keywords_like, ->(keywords) {
     joins(:answers).where('answers.value LIKE ? OR ARRAY_TO_STRING(answers.array_value, \',\') LIKE ?', "%#{keywords}%", "%#{keywords}%")
@@ -67,13 +67,13 @@ class Report < ApplicationRecord
   def self.monthly_reports_for(project)
     start_of_month = Time.zone.now.beginning_of_month
     end_of_month = Time.zone.now.end_of_month
-    Report.where(project: project, updated_at: start_of_month..end_of_month)
+    Report.where(project: project, created_at: start_of_month..end_of_month)
   end
 
   # 週次レポートを取得する
   def self.weekly_reports_for(project)
     start_of_week = Time.zone.now.beginning_of_week
     end_of_week = Time.zone.now.end_of_week
-    Report.where(project: project, updated_at: start_of_week..end_of_week)
+    Report.where(project: project, created_at: start_of_week..end_of_week)
   end
 end

--- a/app/views/projects/counselings/index.html.erb
+++ b/app/views/projects/counselings/index.html.erb
@@ -62,7 +62,7 @@
                       <%= link_to counseling.title, user_project_counseling_path(@user, @project, counseling), class: "counseling-detail-link" %>
                     </div>
                     <div class="counseling-date">
-                      <%= l(counseling.updated_at, format: :long) %>
+                      <%= l(counseling.created_at, format: :long) %>
                     </div>
                     <div class="counseling-person">
                         <%= counseling.sender_name %>
@@ -124,7 +124,7 @@
                       <%= link_to counseling.title, user_project_counseling_path(@user, @project, counseling), class: "counseling-detail-link" %>
                     </div>
                     <div class="counseling-date">
-                      <%= l(counseling.updated_at, format: :long) %>
+                      <%= l(counseling.created_at, format: :long) %>
                     </div>
                     <div class="counseling-person">
                         <%= counseling.sender_name %>

--- a/app/views/projects/messages/index.html.erb
+++ b/app/views/projects/messages/index.html.erb
@@ -65,7 +65,7 @@
                       <%= link_to message.title, user_project_message_path(@user, @project, message), class: "message-detail-link" %>
                     </div>
                     <div class="message-date">
-                      <%= l(message.updated_at, format: :long) %>
+                      <%= l(message.created_at, format: :long) %>
                     </div>
                     <div class="message-person">
                         <%= message.sender_name %>
@@ -126,7 +126,7 @@
                       <%= link_to message.title, user_project_message_path(@user, @project, message), class: "message-detail-link" %>
                     </div>
                     <div class="message-date">
-                      <%= l(message.updated_at, format: :long) %>
+                      <%= l(message.created_at, format: :long) %>
                     </div>
                     <div class="message-person">                     
                        <%= get_message_recipients(message.id, @members) %>
@@ -188,7 +188,7 @@
                       <%= link_to message.title, user_project_message_path(@user, @project, message), class: "report-detail-link" %>
                     </div>
                     <div class="message-date">
-                      <%= l(message.updated_at, format: :long) %>
+                      <%= l(message.created_at, format: :long) %>
                     </div>
                     <div class="message-person">
                         <%= message.sender_name %>

--- a/app/views/projects/reports/index.html.erb
+++ b/app/views/projects/reports/index.html.erb
@@ -35,8 +35,8 @@
                 <%= form_with scope: :search, url: user_project_reports_path(current_user,@project), method: :get, local: true do |form| %>
                   <%= form.hidden_field :search_type, value: "you-report" %>            
 
-                  <%= form.label :updated_at, "報告日：", class: "mb-0" %>
-                  <%= form.date_field :updated_at, placeholder: "報告日を入力", value: @search_params && @search_params[:updated_at], class: "search-box" %>
+                  <%= form.label :created_at, "報告日：", class: "mb-0" %>
+                  <%= form.date_field :created_at, placeholder: "報告日を入力", value: @search_params && @search_params[:created_at], class: "search-box" %>
 
                   <%= form.label :title, "件名：", class: "mb-0" %>
                   <%= form.text_field :title, placeholder: "件名を入力", value: @search_params && @search_params[:title], class: "search-box" %>
@@ -70,7 +70,7 @@
                       <%= link_to "#{report.title}", user_project_report_path(@user, @project, report), class: "report-detail-link" %>
                     </div>
                     <div class="reported-date col-md-4">
-                      <%= l(report.updated_at, format: :long) %>
+                      <%= l(report.created_at, format: :long) %>
                     </div>
                     <%# <div class="report-confirmer">
                       <%= report.report_confirmers.where(report_confirmation_flag: true).count人 %>
@@ -112,8 +112,8 @@
                 <%= form_with scope: :search, url: user_project_reports_path(current_user,@project), method: :get, local: true do |form| %>
                   <%= form.hidden_field :search_type, value: "report" %>                
                   
-                  <%= form.label :updated_at, "報告日：", class: "mb-0" %>
-                  <%= form.date_field :updated_at, placeholder: "報告日を入力", value: @search_params && @search_params[:updated_at], class: "search-box" %>
+                  <%= form.label :created_at, "報告日：", class: "mb-0" %>
+                  <%= form.date_field :created_at, placeholder: "報告日を入力", value: @search_params && @search_params[:created_at], class: "search-box" %>
                   
                   <%= form.label :title, "件名：", class: "mb-0" %>
                   <%= form.text_field :title, placeholder: "件名を入力", value: @search_params && @search_params[:title], class: "search-box" %>
@@ -150,7 +150,7 @@
                       <%= link_to "#{report.title}", user_project_report_path(User.find(report.user_id), @project, report), class: "report-detail-link" %>
                     </div>
                     <div class="reported-date col-md-4">
-                      <%= l(report.updated_at, format: :long) %>
+                      <%= l(report.created_at, format: :long) %>
                     </div>
                     <div class="report-confirmer col-md-4">
                       <%= report.sender_name %>


### PR DESCRIPTION
### 概要
①検索機能の不具合を修正しました。
②報告・連絡・相談の報告日をupdated_at → created_at に変更しました。

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_


### 実装内容・手法
①report_controller.rbのindxアクションにrenderを重複実装していた不具合を修正しました。
②報告日をupdated_atにする事で意味合いが違ってくることの修正。
　updated_at → created_at に変更
※現在、相談の編集削除がプルリクに上がっていない為、相談関係のプルリクを上げるときもcreated_atに合わせた修正で
　上げて頂きたいです。
第一フェーズ終了に向けてテスト実行中であることから不具合部分を取り急ぎ上げさせていただきました。

### 実装画像などあれば添付する

### gemfileの変更
- [x] なし
- [ ] あり 
