### PR TITLE
相談編集・削除機能追加

### DIFF
--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -74,6 +74,17 @@ class Projects::CounselingsController < Projects::BaseProjectController
     end
   end
 
+  def destroy
+    set_project_and_members
+    @counseling = Counseling.find(params[:id])
+    if @counseling.destroy
+      flash[:success] = "「#{@counseling.title}」を削除しました。"
+    else
+      flash[:danger] = "#{@counseling.title}の削除に失敗しました。"
+    end
+    redirect_to user_project_counselings_path(@user, @project)
+  end
+
   # "確認しました"フラグの切り替え。機能を確認してもらい、実装確定後リファクタリング
   def read
     @project = Project.find(params[:project_id])

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -61,6 +61,19 @@ class Projects::CounselingsController < Projects::BaseProjectController
   end
   # rubocop:enable Metrics/AbcSize
 
+  def update
+    set_project_and_members
+    @counseling = @project.counselings.find(params[:id])
+
+    if update_counseling_and_confirmers
+      flash[:success] = "相談内容を更新しました。"
+      redirect_to user_project_counselings_path
+    else
+      flash[:danger] = "送信相手を選択してください。"
+      render action: :edit
+    end
+  end
+
   # "確認しました"フラグの切り替え。機能を確認してもらい、実装確定後リファクタリング
   def read
     @project = Project.find(params[:project_id])
@@ -74,5 +87,41 @@ class Projects::CounselingsController < Projects::BaseProjectController
 
   def counseling_params
     params.require(:counseling).permit(:counseling_detail, :title, { send_to: [] }, :send_to_all)
+  end
+
+  def update_counseling_and_confirmers
+    if @counseling.update(counseling_params)
+      @counseling.counseling_confirmers.destroy_all
+
+      if send_to_all?
+        create_confirmers_for_all_members
+      else
+        create_confirmers_from_send_to
+      end
+
+      true
+    else
+      false
+    end
+  end
+
+  def send_to_all?
+    ActiveRecord::Type::Boolean.new.cast(params[:counseling][:send_to_all])
+  end
+
+  def create_confirmers_for_all_members
+    @members.each do |member|
+      create_confirmer(member.id)
+    end
+  end
+
+  def create_confirmers_from_send_to
+    @counseling.send_to.each do |t|
+      create_confirmer(t)
+    end
+  end
+
+  def create_confirmer(confirmer_id)
+    @counseling.counseling_confirmers.create(counseling_confirmer_id: confirmer_id)
   end
 end

--- a/app/views/projects/counselings/index.html.erb
+++ b/app/views/projects/counselings/index.html.erb
@@ -132,7 +132,7 @@
                     <div class="counseling-action">
                       <% if counseling.sender_id == current_user.id %>
                         <%= link_to "編集", edit_user_project_counseling_path(@user, @project, counseling), class: "btn btn-outline-orange" %>
-                        <%= link_to "削除", "#", method: :delete, data: { confirm: "投稿された連絡を削除してよろしいですか？" }, class: "btn btn-danger" %>
+                        <%= link_to "削除", user_project_counseling_path(@user, @project, counseling), method: :delete, data: { confirm: "投稿された相談を削除してよろしいですか？" }, class: "btn btn-danger" %>
                       <% end %>
                     </div>
                   </div>


### PR DESCRIPTION
### 概要
ほうれんそうアプリ基本設計・機能分類【相談】
①No.170【相談削除機能】相談一覧画面で削除ボタン押下で相談削除ができる
②No.196【相談更新機能】相談編集画面で送信対象（チェックボックス）、件名（３０字以内）、相談内容（５００字以内）を編集後、更新ボタン押下で更新できる

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
①【counselings_controller.rb】にdestroyアクション、【counselings/index.html.erb】に削除ボタン機能を追加
②【counselings_controller.rb】にupdateアクション、103〜137行目にupdate_counseling_and_confirmers、send_to_all?、create_confirmers_for_all_members、create_confirmers_from_send_to、create_confirmer(confirmer_id)アクションを追加

### 実装画像などあれば添付する

### gemfileの変更
- [x] なし
- [ ] あり 
