### PR TITLE
Fix/message tab

### DIFF
--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -52,7 +52,7 @@ class Projects::MessagesController < Projects::BaseProjectController
           @send.save
         end
         flash[:success] = "連絡内容を送信しました。"
-        redirect_to user_project_path current_user, params[:project_id]
+        redirect_to user_project_messages_path current_user, params[:project_id]
       else
         flash[:danger] = "送信相手を選択してください。"
         render action: :new
@@ -65,7 +65,7 @@ class Projects::MessagesController < Projects::BaseProjectController
           @send.save
         end
         flash[:success] = "連絡内容を送信しました。"
-        redirect_to user_project_path current_user, params[:project_id]
+        redirect_to user_project_messages_path current_user, params[:project_id]
       else
         flash[:danger] = "送信相手を選択してください。"
         render :new
@@ -130,7 +130,7 @@ class Projects::MessagesController < Projects::BaseProjectController
         update_message_confirmers_for_selected
       end
       flash[:success] = "連絡内容を更新し、送信しました。"
-      redirect_to user_project_path(current_user, params[:project_id])
+      redirect_to user_project_messages_path(current_user, params[:project_id])
     else
       flash[:danger] = "送信相手を選択してください。"
       render :edit

--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -14,6 +14,10 @@ class Projects::MessagesController < Projects::BaseProjectController
     you_send_message_ids = Message.where(sender_id: current_user.id).pluck(:id)
     @you_send_messages = @project.messages.where(id: you_send_message_ids).order(created_at: 'DESC').page(params[:page]).per(5)
     set_project_and_members
+    @recipient_count = {}
+    @messages.each do |message|
+      @recipient_count[message.id] = message.message_confirmers.count
+    end
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/app/views/projects/messages/index.html.erb
+++ b/app/views/projects/messages/index.html.erb
@@ -185,7 +185,11 @@
                   <% line_num += 1%>
                   <div class="table-line", data-project-index-line-num="<%="#{line_num}"%>">
                     <div class="subject-name">
-                      <%= link_to message.title, user_project_message_path(@user, @project, message), class: "report-detail-link" %>
+                      <% if @you_addressee_messages.present? %>
+                        <%= link_to message.title, user_project_message_path(@user, @project, message), class: "report-detail-link" %>
+                      <% else %>
+                        <%= message.title  %>
+                      <% end %>
                     </div>
                     <div class="message-date">
                       <%= l(message.created_at, format: :long) %>

--- a/app/views/projects/messages/index.html.erb
+++ b/app/views/projects/messages/index.html.erb
@@ -71,7 +71,12 @@
                         <%= message.sender_name %>
                     </div>
                     <div class="message-action">
-                        
+                      <% if message.checked_members.present? %>
+                      <!--checked_membersで対応中だが変える必要あり、現在メンバーの一人がチェックすると既読になる状況です。-->                      
+                        <P>既読</P>                        
+                      <% else %>
+                        <%= link_to "未読", user_project_message_path(@user, @project, message), class: "message-detail-link text-danger font-weight-bold" %>                       
+                      <% end %>                        
                     </div>
                   </div>
                 <% end %>
@@ -195,12 +200,12 @@
                       <%= l(message.created_at, format: :long) %>
                     </div>
                     <div class="message-person">
-                        <%= message.sender_name %>
+                      <%= message.sender_name %>
                     </div>
-                    <div class="message-action">
-                      <% if message.sender_id == current_user.id %>
-                        
-                      <% end %>
+                    <div class="message-action">                      
+                      <%= message.checked_members.count %>人/
+                      <% count = @recipient_count[message.id] %>
+                      <%= "#{count}人" if count.present? %>
                     </div>
                   </div>
                 <% end %>

--- a/app/views/projects/messages/index.html.erb
+++ b/app/views/projects/messages/index.html.erb
@@ -24,7 +24,7 @@
           <a class="text-white" id="you-send-tab" data-toggle="tab" href="#you-send" target="_blank" rel="external nofollow"  role="tab" aria-controls="you-send" aria-selected="false">▼ あなたが送った連絡 ▼</a>
         </li>
         <li class="nav-item">
-          <a class="text-white" id="message-tab" data-toggle="tab" href="#message" target="_blank" rel="external nofollow"  role="tab" aria-controls="message" aria-selected="false">▼ 全メンバーへの連絡 ▼</a>
+          <a class="text-white" id="message-tab" data-toggle="tab" href="#message" target="_blank" rel="external nofollow"  role="tab" aria-controls="message" aria-selected="false">▼ 全連絡 ▼</a>
         </li>
       </ul>
     </div>

--- a/app/views/projects/messages/index.html.erb
+++ b/app/views/projects/messages/index.html.erb
@@ -71,9 +71,8 @@
                         <%= message.sender_name %>
                     </div>
                     <div class="message-action">
-                      <% if message.checked_members.present? %>
-                      <!--checked_membersで対応中だが変える必要あり、現在メンバーの一人がチェックすると既読になる状況です。-->                      
-                        <P>既読</P>                        
+                      <% if message.message_confirmers.exists?(message_confirmer_id: current_user.id, message_confirmation_flag: true) %>
+                        <P>既読</P>
                       <% else %>
                         <%= link_to "未読", user_project_message_path(@user, @project, message), class: "message-detail-link text-danger font-weight-bold" %>                       
                       <% end %>                        
@@ -190,7 +189,7 @@
                   <% line_num += 1%>
                   <div class="table-line", data-project-index-line-num="<%="#{line_num}"%>">
                     <div class="subject-name">
-                      <% if @you_addressee_messages.present? %>
+                      <% if message.message_confirmers.exists?(message_confirmer_id: current_user.id) %>
                         <%= link_to message.title, user_project_message_path(@user, @project, message), class: "report-detail-link" %>
                       <% else %>
                         <%= message.title  %>


### PR DESCRIPTION
### 概要
・連絡作成・更新遷移先不具合修正
・全メッセージ表示で自分に送られていないメッセージのリンクを外す。
・全メッセージ、送信人数と既読人数の確認。
### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法

【修正・追加機能】
・連絡の作成、更新後、プロジェクト詳細ページへ遷移する不具合を連絡一覧に遷移するようにしました。
・現在、全メッセージで自分宛ではないメンバーもタイトルリンクになっているものを外しました。
（自分宛でないリンクをクリックしてもプロジェクト一覧に遷移してしまうため。）
・全のメッセージ表示の連絡の既読人数/メッセージを送った人数を表示できるようにしました。
【実装途中】
・あなたに送ったメッセージの既読・未読機能を表示できるようにしたかったのですが、現在メンバーの一人がチェックを入れると既読になってしまいます。
（次のタスクに回します。）
・タブの不具合を修正したかったのですが、JavaScriptの知識が足りなく手が付けられていません。勉強中です。
なので名前がちぐはぐになってしまいました。

とりあえず、遷移先の不具合を修正したかったので、中途半端な状態ですがプルリクに上げさせていただきます。
不備が多くてすみません。エラーは出ていないと思います。
### 実装画像などあれば添付する

### gemfileの変更
- [x] なし
- [ ] あり 
