### PR TITLE
報告通知機能実装

### DIFF
--- a/app/assets/stylesheets/project.scss
+++ b/app/assets/stylesheets/project.scss
@@ -187,7 +187,7 @@
 
 ////////// 一覧の列のデザイン //////////
 .project-name, .subject-name, .member-name, .project-next-report-date,
-.reported-date, .report-confirmer, .report-person, .report-action, 
+.reported-date, .report-confirmer, .report-person, .report-action, .report_read,
 .message-date, .message-confirmer, .message-person, .message-action,
 .counseling-date, .counseling-confirmer, .counseling-person, .counseling-action {
   width: 25%;

--- a/app/controllers/projects/reports_controller.rb
+++ b/app/controllers/projects/reports_controller.rb
@@ -68,6 +68,7 @@ class Projects::ReportsController < Projects::BaseProjectController
     @report = @project.reports.new(create_reports_params)
     @report.sender_id = @user.id
     @report.sender_name = @user.name
+    @report.report_read_flag = false
     @report.answers.each do |answer|
       answer.question_name = answer.question_type.camelize.constantize.find_by(question_id: answer.question_id).label_name
     end

--- a/app/controllers/projects/reports_controller.rb
+++ b/app/controllers/projects/reports_controller.rb
@@ -41,6 +41,11 @@ class Projects::ReportsController < Projects::BaseProjectController
     @user = User.find(params[:user_id])
     @report = Report.find(params[:id])
     @answers = @report.answers
+    @project = Project.find(params[:project_id])
+    if current_user && current_user.id == @project.leader_id
+      # 既読フラグを設定
+      @report.update(report_read_flag: true)
+    end
   end
 
   def new

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -7,6 +7,7 @@ class Report < ApplicationRecord
   accepts_nested_attributes_for :answers, allow_destroy: true
   attribute :remanded, default: false
   attribute :resubmitted, default: false
+  attribute :report_read_flag, default: false
 
   # validates :report_detail, presence: true
   validates :title, presence: true, length: { maximum: 30 }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,6 +4,8 @@ class Report < ApplicationRecord
   has_many :answers, dependent: :destroy
   has_many :report_confirmers, dependent: :destroy
 
+  attr_accessor :leader_id
+
   accepts_nested_attributes_for :answers, allow_destroy: true
   attribute :remanded, default: false
   attribute :resubmitted, default: false

--- a/app/views/projects/projects/index.html.erb
+++ b/app/views/projects/projects/index.html.erb
@@ -70,6 +70,15 @@
                   <span>に修正依頼が来ています。</span></p>
                 <% end %>
             <% end %>
+            
+            <% unread_report = project.reports.where(report_read_flag: "false") %>
+            <% if current_user.id == project.leader_id %>
+              <% if unread_report.count > 0 %>
+                <p><%= link_to "未読の報告", user_project_reports_path(@user, project) %>
+                <span>があります。</span></p>
+              <% end %>
+            <% end %>
+            
             <% messages = project.messages.my_messages(@user) %>
             <% if messages.count > 0 %>
                 <p><%= link_to "新着の連絡", user_project_messages_path(@user, project) %>
@@ -81,8 +90,12 @@
                 <span>が<%= "#{counselings.count}件あります。" %></span></p>
             <% end %>
             <% counselings = project.counselings.my_counselings(@user) %>
-            <% if remanded_reports.empty? && messages.empty? && counselings.empty? && resubmitted_reports.empty? %>
+            <% if current_user.id == project.leader_id %>
+              <% if remanded_reports.empty? && unread_report.empty? && messages.empty? && counselings.empty? && resubmitted_reports.empty? %>
                 <p>無し</p>
+              <% end %>
+            <% elsif remanded_reports.empty? && messages.empty? && counselings.empty? && resubmitted_reports.empty? %>
+              <p>無し</p>
             <% end %>
           </div>
         </div>

--- a/app/views/projects/reports/index.html.erb
+++ b/app/views/projects/reports/index.html.erb
@@ -48,37 +48,80 @@
                 <% end %>
               </div>            
               <div class="table-header">
-                <div class="subject-name col-md-4">
-                  <%=@project.format.title%>
-                </div>
-                <div class="reported-date col-md-4">
-                  報告日
-                </div>
-                <%# <div class="report-confirmer">
-                  確認者
-                </div> %>
-                <div class="report-action col-md-4">
-                  アクション
-                </div>
+                <% if current_user.id == @project.leader_id %>
+                  <div class="subject-name col-md-4">
+                    <%=@project.format.title%>
+                  </div>
+                  <div class="reported-date col-md-4">
+                    報告日
+                  </div>
+                  <%# <div class="report-confirmer">
+                    確認者
+                  </div> %>
+                  <div class="report-action col-md-4">
+                    アクション
+                  </div>
+                <% else %>
+                  <div class="subject-name col-md-3">
+                    <%=@project.format.title%>
+                  </div>
+                  <div class="reported-date col-md-3">
+                    報告日
+                  </div>
+                  <%# <div class="report-confirmer">
+                    確認者
+                  </div> %>
+                  <div class="report-action col-md-3">
+                    アクション
+                  </div>
+                  <div class="report_read col-md-2.5">
+                    リーダー確認状況
+                  </div>
+                <% end %>
               </div>
               <div class="table-body">
                 <% line_num = 0%>
                 <% @you_reports.each do |report|%>
                   <% line_num += 1%>
                   <div class="table-line", data-project-index-line-num="<%="#{line_num}"%>" id="you_report_<%= report.id %>">
-                    <div class="subject-name col-md-4">
-                      <%= link_to report.title, user_project_report_path(@user, @project, report), class: "report-detail-link" %>
-                    </div>
-                    <div class="reported-date col-md-4">
-                      <%= l(report.created_at, format: :long) %>
-                    </div>
-                    <%# <div class="report-confirmer">
-                      <%= report.report_confirmers.where(report_confirmation_flag: true).count人 %>
-                    <%# </div> %>
-                    <div class="report-action col-md-4">
-                      <%= link_to "編集", edit_user_project_report_path(@user, @project, report), class: "btn btn-outline-orange" %>
-                      <%= link_to "削除", user_project_report_path(@user, @project, report), method: :delete, data: { confirm: "投稿された報告を削除してよろしいですか？" }, class: "btn btn-danger" %>
-                    </div>
+                    <% if current_user.id == @project.leader_id %>
+                      <div class="subject-name col-md-4">
+                        <%= link_to report.title, user_project_report_path(@user, @project, report), class: "report-detail-link" %>
+                      </div>
+                      <div class="reported-date col-md-4">
+                        <%= l(report.created_at, format: :long) %>
+                      </div>
+                      <%# <div class="report-confirmer">
+                        <%= report.report_confirmers.where(report_confirmation_flag: true).count人 %>
+                      <%# </div> %>
+                      <div class="report-action col-md-4">
+                        <%= link_to "編集", edit_user_project_report_path(@user, @project, report), class: "btn btn-outline-orange" %>
+                        <%= link_to "削除", user_project_report_path(@user, @project, report), method: :delete, data: { confirm: "投稿された報告を削除してよろしいですか？" }, class: "btn btn-danger" %>
+                      </div>
+                    <% else %>
+                      <div class="subject-name col-md-3">
+                        <%= link_to report.title, user_project_report_path(@user, @project, report), class: "report-detail-link" %>
+                      </div>
+                      <div class="reported-date col-md-3">
+                        <%= l(report.created_at, format: :long) %>
+                      </div>
+                      <%# <div class="report-confirmer">
+                        <%= report.report_confirmers.where(report_confirmation_flag: true).count人 %>
+                      <%# </div> %>
+                      <div class="report-action col-md-3">
+                        <%= link_to "編集", edit_user_project_report_path(@user, @project, report), class: "btn btn-outline-orange" %>
+                        <%= link_to "削除", user_project_report_path(@user, @project, report), method: :delete, data: { confirm: "投稿された報告を削除してよろしいですか？" }, class: "btn btn-danger" %>
+                      </div>
+                      <% if report.report_read_flag == true %>
+                        <div class="report_read col-md-2.5">
+                          <p>既読</p>
+                        </div>
+                      <% else %>
+                        <div class="report_read col-md-2.5 text-danger font-weight-bold" >
+                          <p>未読</p>
+                        </div>
+                      <% end %>
+                    <% end %>
                   </div>
                 <% end %>
               </div>
@@ -128,37 +171,73 @@
                 <% end %>
               </div>            
               <div class="table-header">
-                <div class="subject-name col-md-4">
-                  <%=@project.format.title%>
-                </div>
-                <div class="reported-date col-md-4">
-                  報告日
-                </div>
-                <div class="report-confirmer col-md-4">
-                  報告者
-                </div>
-                <%# <div class="report-action">
-                  アクション
-                </div> %>
+                <% if current_user.id == @project.leader_id %>
+                  <div class="subject-name col-md-3">
+                    <%=@project.format.title%>
+                  </div>
+                  <div class="reported-date col-md-3">
+                    報告日
+                  </div>
+                  <div class="report-confirmer col-md-3">
+                    報告者
+                  </div>
+                  <div class="report_read col-md-2.5">
+                    報告確認状況
+                  </div>
+                <% else %>
+                  <div class="subject-name col-md-4">
+                    <%=@project.format.title%>
+                  </div>
+                  <div class="reported-date col-md-4">
+                    報告日
+                  </div>
+                  <div class="report-confirmer col-md-4">
+                    報告者
+                  </div>
+                  <%# <div class="report-action">
+                    アクション
+                  </div> %>
+                <% end %>
               </div>
               <div class="table-body">
                 <% line_num = 0%>
                 <% @reports.each do |report|%>
                   <% line_num += 1%>
                   <div class="table-line", data-project-index-line-num="<%="#{line_num}"%>" id="you_report_<%= report.id %>">
-                    <div class="subject-name col-md-4">
-                      <%= link_to report.title, user_project_report_path(@user, @project, report), class: "report-detail-link" %>
-                    </div>
-                    <div class="reported-date col-md-4">
-                      <%= l(report.created_at, format: :long) %>
-                    </div>
-                    <div class="report-confirmer col-md-4">
-                      <%= report.sender_name %>
-                    </div>
-                    <%# <div class="report-action"> %>
-                      <%# link_to "編集", edit_user_project_report_path(@user, @project, report), class: "btn btn-outline-orange" %>
-                      <%# link_to "削除", user_project_report_path(@user, @project, report), method: :delete, data: { confirm: "投稿された報告を削除してよろしいですか？" }, class: "btn btn-danger" %>
-                    <%# </div> %>
+                    <% if current_user.id == @project.leader_id %>
+                      <div class="subject-name col-md-3">
+                        <%= link_to report.title, user_project_report_path(@user, @project, report), class: "report-detail-link" %>
+                      </div>
+                      <div class="reported-date col-md-3">
+                        <%= l(report.created_at, format: :long) %>
+                      </div>
+                      <div class="report-confirmer col-md-3">
+                        <%= report.sender_name %>
+                      </div>
+                      <% if report.report_read_flag == true %>
+                        <div class="report_read col-md-2.5">
+                          <p>既読</p>
+                        </div>
+                      <% else %>
+                        <div class="report_read col-md-2.5 text-danger font-weight-bold" >
+                          <p>未読</p>
+                        </div>
+                      <% end %>
+                    <% else %>
+                      <div class="subject-name col-md-4">
+                        <%= link_to report.title, user_project_report_path(@user, @project, report), class: "report-detail-link" %>
+                      </div>
+                      <div class="reported-date col-md-4">
+                        <%= l(report.created_at, format: :long) %>
+                      </div>
+                      <div class="report-confirmer col-md-4">
+                        <%= report.sender_name %>
+                      </div>
+                      <%# <div class="report-action"> %>
+                        <%# link_to "編集", edit_user_project_report_path(@user, @project, report), class: "btn btn-outline-orange" %>
+                        <%# link_to "削除", user_project_report_path(@user, @project, report), method: :delete, data: { confirm: "投稿された報告を削除してよろしいですか？" }, class: "btn btn-danger" %>
+                      <%# </div> %>
+                    <% end %>
                   </div>
                 <% end %>
               </div>

--- a/app/views/projects/reports/show.html.erb
+++ b/app/views/projects/reports/show.html.erb
@@ -39,13 +39,6 @@ function changeForm() {
     <div class="card">
       <div class="card-header card-header-radius">
         <%= @report.sender_name %>さんの報告
-        <% if @report.report_read_flag == false %>
-          <p>false</p>
-        <% elsif @report.report_read_flag == true %>
-          <p>true</p>
-        <% else %>
-          <p>null</p>
-        <% end %>
       </div>
       <div class="card-body">
         <div class="container mb-4">

--- a/app/views/projects/reports/show.html.erb
+++ b/app/views/projects/reports/show.html.erb
@@ -39,6 +39,13 @@ function changeForm() {
     <div class="card">
       <div class="card-header card-header-radius">
         <%= @report.sender_name %>さんの報告
+        <% if @report.report_read_flag == false %>
+          <p>false</p>
+        <% elsif @report.report_read_flag == true %>
+          <p>true</p>
+        <% else %>
+          <p>null</p>
+        <% end %>
       </div>
       <div class="card-body">
         <div class="container mb-4">

--- a/app/views/projects/reports/show.html.erb
+++ b/app/views/projects/reports/show.html.erb
@@ -38,7 +38,7 @@ function changeForm() {
   <div>
     <div class="card">
       <div class="card-header card-header-radius">
-        <%= @user.name %>さんの報告
+        <%= @report.sender_name %>さんの報告
       </div>
       <div class="card-body">
         <div class="container mb-4">

--- a/db/migrate/20231022103757_add_column_to_reports.rb
+++ b/db/migrate/20231022103757_add_column_to_reports.rb
@@ -1,0 +1,5 @@
+class AddColumnToReports < ActiveRecord::Migration[5.2]
+  def change
+    add_column :reports, :report_read_flag, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_14_132005) do
+ActiveRecord::Schema.define(version: 2023_10_22_103757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -209,6 +209,7 @@ ActiveRecord::Schema.define(version: 2023_08_14_132005) do
     t.boolean "resubmitted"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "report_read_flag"
     t.index ["project_id"], name: "index_reports_on_project_id"
     t.index ["user_id"], name: "index_reports_on_user_id"
   end


### PR DESCRIPTION
### 概要
報告既読・未読機能、報告未読の通知機能を追加。

### タスク
- [ ] なし
- [x] あり _(タスクのリンクがあれば貼る)_
・未読報告の通知（機能分類No.200、No.48）
https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit#gid=1075510033&range=B191
・報告確認状況（未読・既読）の表示（機能分類No.201、No.202）
https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit#gid=1075510033&range=B193
・報告詳細画面表示で既読をつける（機能分類No.203）
https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit#gid=1075510033&range=B195

### 実装内容・手法
マイグレーションファイルを作成し、reportsテーブルに「report_read_flag」カラムを追加。(boolean型)
デフォルトはfalse。falseは未読、trueは既読。
報告作成時にreport_read_flagがfalseで保存される。
リーダーが他メンバーの報告詳細表示で、report_read_flagがtrueになる。
report_read_flagの値をもとに、既読や未読を表示する。

### 実装画像などあれば添付する
実装画面
https://docs.google.com/spreadsheets/d/1GNKRF2oDCLZ-0CO3P3A3jE0o7YKU03XpwkC-scoc0W8/edit#gid=0

### gemfileの変更
- [x] なし
- [ ] あり 
