### PR TITLE
相談通知機能追加

### DIFF
--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -78,8 +78,10 @@ class Projects::CounselingsController < Projects::BaseProjectController
   def update
     set_project_and_members
     @counseling = @project.counselings.find(params[:id])
-
+  
     if update_counseling_and_confirmers
+      send_edited_notification_emails
+  
       flash[:success] = "相談内容を更新しました。"
       redirect_to user_project_counselings_path
     else
@@ -148,5 +150,12 @@ class Projects::CounselingsController < Projects::BaseProjectController
 
   def create_confirmer(confirmer_id)
     @counseling.counseling_confirmers.create(counseling_confirmer_id: confirmer_id)
+  end
+
+  def send_edited_notification_emails
+    @counseling.send_to.each do |recipient_id|
+      recipient = User.find(recipient_id)
+      CounselingMailer.notification_edited(recipient, @counseling, @project, @counseling.token).deliver_now
+    end
   end
 end

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -78,10 +78,10 @@ class Projects::CounselingsController < Projects::BaseProjectController
   def update
     set_project_and_members
     @counseling = @project.counselings.find(params[:id])
-  
+
     if update_counseling_and_confirmers
       send_edited_notification_emails
-  
+
       flash[:success] = "相談内容を更新しました。"
       redirect_to user_project_counselings_path
     else

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -11,13 +11,13 @@ class Projects::CounselingsController < Projects::BaseProjectController
   def show
     set_project_and_members
     @counseling = Counseling.find_by(id: params[:id])
-    
+
     if @counseling.nil?
       flash[:alert] = "相談は削除されました。"
       redirect_to user_project_counselings_path(@user, @project) # または適切なパスに変更
       return
     end
-    
+
     @checked_members = @counseling.checked_members
     @counseling_c = @counseling.counseling_confirmers.find_by(counseling_confirmer_id: current_user)
   end

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -153,8 +153,9 @@ class Projects::CounselingsController < Projects::BaseProjectController
   end
 
   def send_edited_notification_emails
-    @counseling.send_to.each do |recipient_id|
-      recipient = User.find(recipient_id)
+    recipients = @counseling.send_to_all ? @members : @counseling.send_to
+    recipients.each do |recipient|
+      recipient = recipient.is_a?(User) ? recipient : User.find(recipient)
       CounselingMailer.notification_edited(recipient, @counseling, @project, @counseling.token).deliver_now
     end
   end

--- a/app/mailers/counseling_mailer.rb
+++ b/app/mailers/counseling_mailer.rb
@@ -1,0 +1,14 @@
+class CounselingMailer < ApplicationMailer
+
+  def notification(user, counseling, project, token)
+    @user = user
+    @counseling = counseling
+    @project = project
+    @token = token
+    @project_name = project.name
+    @sender_name = User.find(@counseling.sender_id).name
+    @counseling_title = counseling.title
+    
+    mail(to: @user.email, subject: '相談が届きました')
+  end
+end

--- a/app/mailers/counseling_mailer.rb
+++ b/app/mailers/counseling_mailer.rb
@@ -1,5 +1,4 @@
 class CounselingMailer < ApplicationMailer
-
   def notification(user, counseling, project, token)
     @user = user
     @counseling = counseling
@@ -8,7 +7,7 @@ class CounselingMailer < ApplicationMailer
     @project_name = project.name
     @sender_name = User.find(@counseling.sender_id).name
     @counseling_title = counseling.title
-    
-    mail(to: @user.email, subject: '相談が届きました')
+
+    mail(to: @user.email, subject: I18n.t('counseling_mailer.consultation_arrived'))
   end
 end

--- a/app/mailers/counseling_mailer.rb
+++ b/app/mailers/counseling_mailer.rb
@@ -10,4 +10,16 @@ class CounselingMailer < ApplicationMailer
 
     mail(to: @user.email, subject: I18n.t('counseling_mailer.consultation_arrived'))
   end
+
+  def notification_edited(user, counseling, project, token)
+    @user = user
+    @counseling = counseling
+    @project = project
+    @token = token
+    @project_name = project.name
+    @sender_name = User.find(@counseling.sender_id).name
+    @counseling_title = counseling.title
+
+    mail(to: @user.email, subject: I18n.t('counseling_mailer.consultation_edited_arrived'))
+  end
 end

--- a/app/views/counseling_mailer/notification.html.erb
+++ b/app/views/counseling_mailer/notification.html.erb
@@ -1,0 +1,5 @@
+<h3>プロジェクト名：<%= @project_name %></h3>
+
+<h2><%= "#{@sender_name}さんから相談がありました。" %></h2>
+  <p>下記のリンクより確認できます。</p>
+  <%= link_to @counseling_title, user_project_counseling_url(@user, @project, @counseling, token: @token) %>

--- a/app/views/counseling_mailer/notification.html.erb
+++ b/app/views/counseling_mailer/notification.html.erb
@@ -1,5 +1,5 @@
 <h3>プロジェクト名：<%= @project_name %></h3>
 
 <h2><%= "#{@sender_name}さんから相談がありました。" %></h2>
-  <p>下記のリンクより確認できます。</p>
-  <%= link_to @counseling_title, user_project_counseling_url(@user, @project, @counseling, token: @token) %>
+<p>下記のリンクより確認できます。</p>
+<%= link_to @counseling_title, user_project_counseling_url(@user, @project, @counseling, token: @token) %>

--- a/app/views/counseling_mailer/notification_edited.html.erb
+++ b/app/views/counseling_mailer/notification_edited.html.erb
@@ -1,0 +1,5 @@
+<h3>プロジェクト名： <%= @project_name %></h3>
+
+<h2><%= @sender_name %>さんからの相談内容が更新されました。</h2>
+<p>下記のリンクより確認できます。</p>
+<p><%= link_to @counseling_title, user_project_counseling_url(@user, @project, @counseling, token: @token) %></p>

--- a/app/views/projects/counselings/edit.html.erb
+++ b/app/views/projects/counselings/edit.html.erb
@@ -11,7 +11,7 @@
     <div class="ml-3 mb-3 form col-11">
       <% if @members.present? %>
         <%= f.check_box :send_to_all, {}, true, false %>TO ALL<br>
-        <%= f.collection_check_boxes :send_to, @members, :id, :name, include_hidden: false, class: "form-control", checked: @counseling.counseling_confirmers.pluck(:counseling_confirmer_id) %>
+        <%= f.collection_check_boxes :send_to, @members, :id, :name, include_hidden: false, class: "form-control", required: true %>
       <% else %>
         <p class="text-center font-weight-bold text-danger">送信対象がいません</p>
       <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -121,3 +121,4 @@ ja:
     pm: 午後
   counseling_mailer:
     consultation_arrived: "相談が届きました"
+    consultation_edited_arrived: "相談内容が更新されました"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -119,4 +119,5 @@ ja:
       h: "%-H"
       posting: "%Y年%m月%d日(%a) %H時%M分"
     pm: 午後
-
+  counseling_mailer:
+    consultation_arrived: "相談が届きました"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,9 @@ ActiveRecord::Schema.define(version: 2023_10_28_105034) do
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "token"
     t.index ["project_id"], name: "index_counselings_on_project_id"
+    t.index ["token"], name: "index_counselings_on_token", unique: true
   end
 
   create_table "date_fields", force: :cascade do |t|


### PR DESCRIPTION
### 概要
相談が新規作成、編集されて送信された際に、送信相手へメールで通知が届く

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
【app/controllers/projects/counselings_controller.rb】
※追加
・create　相談作成時の通知機能
・show　相談が削除された際のフラッシュメッセージ
・update 相談更新時の通知機能
・send_edited_notification_emailsメソッド追加
【app/mailers/counseling_mailer.rb】
※新規作成
通知メールヘッダー
【app/views/counseling_mailer/notification.html.erb】
【app/views/counseling_mailer/notification_edited.html.erb】
※新規作成
通知メール内容
【app/views/projects/counselings/edit.html.erb】
※修正
相談編集画面の送信対象がチェックされていない状態になるよう修正
【db/schema.rb】
※追加
通知メールから相談詳細に入れるようにするため、counselingsテーブルにtokenを追加
【config/locales/ja.yml】
※追加
RuboCopの指摘により、通知メールヘッダーの 「相談が届きました」「相談内容が更新されました」を ja.ymlに追加し、counseling_mailer.rbでI18n.tメソッドを使用

### 実装画像などあれば添付する
https://docs.google.com/spreadsheets/d/1zZuioWUIBcg-FuWLLUdkpbVa4anMRSBjtn2VGlLcIsM/edit#gid=1887172196
### gemfileの変更
- [x] なし
- [ ] あり 
