### PR TITLE
連絡返信機能の追加

### DIFF
--- a/.rubocop_todo1.yml
+++ b/.rubocop_todo1.yml
@@ -130,6 +130,7 @@ Rails/I18nLocaleTexts:
     - 'app/controllers/projects/counselings_controller.rb'
     - 'app/controllers/projects/members_controller.rb'
     - 'app/controllers/projects/messages_controller.rb'
+    - 'app/controllers/projects/message_replys_controller.rb'
     - 'app/controllers/projects/projects_controller.rb'
     - 'app/controllers/projects/reports_controller.rb'
     - 'app/controllers/projects/report_replys_controller.rb'

--- a/app/controllers/projects/base_project_controller.rb
+++ b/app/controllers/projects/base_project_controller.rb
@@ -31,6 +31,21 @@ class Projects::BaseProjectController < Users::BaseUserController
     redirect_to edit_user_registration_path(current_user)
   end
 
+  # 画像添付機能：使用する画像リストの設定 (プレビュー表示時に取り消しした画像をDBに登録しないための処置）
+  def set_enable_images(image_enable_info, images_array)
+    rmv_num = 0
+    img_enable_array = image_enable_info.split(',')
+
+    img_enable_array.each_with_index do |value, idx|
+      if value == "false"
+        images_array.delete_at(idx - rmv_num)
+        rmv_num += 1
+      end
+    end
+
+    return images_array
+  end
+
   private
 
   # ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓ before_action（権限関連） ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓

--- a/app/controllers/projects/message_replys_controller.rb
+++ b/app/controllers/projects/message_replys_controller.rb
@@ -1,0 +1,84 @@
+class Projects::MessageReplysController < Projects::BaseProjectController
+  before_action :project_authorization, only: %i[edit create update destroy cancel delete_image]
+
+  def edit
+    @message = Message.find(params[:message_id])
+    @reply = MessageReply.find(params[:id])
+    @index = params[:index]
+  end
+
+  def create
+    @@message = Message.find(params[:message_id])
+    unless params[:message_reply][:images].nil?
+      set_enable_images(params[:message_reply][:image_enable], params[:message_reply][:images])
+    end
+    @reply = @@message.message_replies.new(message_reply_params)
+    if @reply.save
+      flash[:success] = '返信を投稿しました。'
+    else
+      flash[:danger] = '返信の投稿に失敗しました。'
+    end
+    redirect_to user_project_message_path(@user, @project, @@message)
+  end
+
+  def update
+    @@message = Message.find(params[:message_id])
+    @reply = MessageReply.find(params[:id])
+    if @reply.update(message_reply_params)
+      flash[:success] = "返信内容を更新しました。"
+    else
+      flash[:danger] = "返信の更新に失敗しました。"
+    end
+    redirect_to user_project_message_path(@user, @project, @@message)
+  end
+
+  def destroy
+    @message = Message.find(params[:message_id])
+    @reply = MessageReply.find(params[:id])
+    @reply.images.purge  # 返信に紐づく画像データの削除
+    if @reply.destroy
+      flash[:success] = "返信を削除しました。"
+    else
+      flash[:danger] = "返信の削除に失敗しました。"
+    end
+    redirect_to user_project_message_path(@user, @project, @message)
+  end
+
+  def cancel
+    @message = Message.find(params[:message_id])
+    @reply = MessageReply.find(params[:id])
+    @index = params[:index]
+  end
+
+  def show_image
+    @image = ActiveStorage::Attachment.find(params[:image_id])
+  end
+
+  def delete_image
+    @message = Message.find(params[:message_id])
+    @image = ActiveStorage::Attachment.find(params[:image_id])
+    @image.purge
+    flash[:success] = "画像を削除しました。"
+    redirect_to user_project_message_path(@user, @project, @message)
+  end
+
+  private
+
+  def message_reply_params
+    params.require(:message_reply).permit(:reply_content, :poster_name, :poster_id, images: [])
+  end
+
+  def set_enable_images(image_enable_info, images_array)
+    rmv_num = 0
+    img_enable_array = image_enable_info.split(',')
+
+    img_enable_array.each_with_index do |value, idx|
+      if value == "false"
+        images_array.delete_at(idx - rmv_num)
+        rmv_num += 1
+      end
+    end
+
+    return images_array
+  end
+end

--- a/app/controllers/projects/message_replys_controller.rb
+++ b/app/controllers/projects/message_replys_controller.rb
@@ -67,18 +67,4 @@ class Projects::MessageReplysController < Projects::BaseProjectController
   def message_reply_params
     params.require(:message_reply).permit(:reply_content, :poster_name, :poster_id, images: [])
   end
-
-  def set_enable_images(image_enable_info, images_array)
-    rmv_num = 0
-    img_enable_array = image_enable_info.split(',')
-
-    img_enable_array.each_with_index do |value, idx|
-      if value == "false"
-        images_array.delete_at(idx - rmv_num)
-        rmv_num += 1
-      end
-    end
-
-    return images_array
-  end
 end

--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -48,6 +48,8 @@ class Projects::MessagesController < Projects::BaseProjectController
     @message = Message.find(params[:id])
     @checked_members = @message.checked_members
     @message_c = @message.message_confirmers.find_by(message_confirmer_id: current_user)
+    @reply = @message.message_replies.new
+    @message_replies = @message.message_replies.all.order(:created_at)
   end
 
   def new

--- a/app/controllers/projects/report_replys_controller.rb
+++ b/app/controllers/projects/report_replys_controller.rb
@@ -67,18 +67,4 @@ class Projects::ReportReplysController < Projects::BaseProjectController
   def report_reply_params
     params.require(:report_reply).permit(:reply_content, :poster_name, :poster_id, images: [])
   end
-
-  def set_enable_images(image_enable_info, images_array)
-    rmv_num = 0
-    img_enable_array = image_enable_info.split(',')
-
-    img_enable_array.each_with_index do |value, idx|
-      if value == "false"
-        images_array.delete_at(idx - rmv_num)
-        rmv_num += 1
-      end
-    end
-
-    return images_array
-  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,6 +1,7 @@
 class Message < ApplicationRecord
   belongs_to :project
   has_many :message_confirmers, dependent: :destroy
+  has_many :message_replies, dependent: :destroy
 
   attr_accessor :send_to
 

--- a/app/models/message_reply.rb
+++ b/app/models/message_reply.rb
@@ -1,0 +1,6 @@
+class MessageReply < ApplicationRecord
+  belongs_to :message
+  has_many_attached :images, dependent: :destroy
+
+  validates :reply_content, presence: true
+end

--- a/app/views/projects/message_replys/_message_reply_edit.html.erb
+++ b/app/views/projects/message_replys/_message_reply_edit.html.erb
@@ -1,0 +1,6 @@
+<%= form_with(model: @reply, url: user_project_message_message_reply_path(@user,@project,@message,@reply), method: :patch) do |f| %>
+  <!-- 返信本文 -->
+  <%= f.text_area :reply_content,class: "textlines", rows: "3", required: true %>
+  <%= f.submit "更新する", class: "btn btn-primary btn-sm" %>
+  <%= link_to "キャンセル", cancel_user_project_message_message_reply_path(@user,@project,@message,@reply, index: @index), class: "btn btn-secondary btn-sm", remote: true %>
+<% end %>

--- a/app/views/projects/message_replys/_message_reply_form.html.erb
+++ b/app/views/projects/message_replys/_message_reply_form.html.erb
@@ -1,0 +1,26 @@
+<div class="col-12 container box-message-format-new pb-2 my-5">
+	<label id="reply_form" class="font-weight-bold message-title-box"><font size="3">返信フォーム</font></label>
+	
+	<%= form_with(model: @reply, url: user_project_message_message_replys_path(@user,@project,@message), method: :post) do |f| %>
+		<!-- 返信本文 -->
+		<%= f.text_area :reply_content, class: "col-11 form-control message-area mb-3", rows: "6", placeholder: "返信する…", required: true %>
+		<!-- 画像選択 -->
+		<label class="reply-image-label">
+			<span class="btn btn-light"><font size="2">📁画像アップロード</font></span>
+			<%= f.file_field :images, multiple: true, accept: 'image/*', class: "reply-image-form", onchange: "preview_images(this)" %>
+		</label>
+		<div class="images_area">
+			<!-- プレビュー画像が表示される -->
+		</div>
+		<!-- 画像使用有無 -->
+		<%= f.hidden_field :image_enable, id: "hiddenInput", :value => "" %>
+		<!-- 投稿者名 -->
+		<%= f.hidden_field :poster_name, :value => current_user.name %>
+		<!-- 投稿者ID -->
+		<%= f.hidden_field :poster_id, :value => current_user.id %>
+		<!-- 返信投稿 -->
+		<div class="text-center mr-4">
+			<%= f.submit "投稿する", class: "btn btn-light btn-outline-orange" %>
+		</div>
+	<% end %>
+</div>

--- a/app/views/projects/message_replys/_message_reply_list.html.erb
+++ b/app/views/projects/message_replys/_message_reply_list.html.erb
@@ -1,0 +1,22 @@
+<hr>
+<details>
+  <summary>
+    <u><%= @message_replies.size %>件の返信</u>
+  </summary>
+  <hr>
+  <% @message_replies.each_with_index do |reply, i| %>
+    <!-- 投稿者名 -->
+    👤<b><%= reply.poster_name %></b>
+    <font size="1"><%= l(reply.updated_at, format: :posting) %></font>
+    <% if reply.poster_id == current_user.id %>
+      <%= link_to "編集する", edit_user_project_message_message_reply_path(@user,@project,@message,reply,index: i ), class: "btn btn-primary btn-sm", remote: true %>
+      <%= link_to "削除する", user_project_message_message_reply_path(@user,@project,@message,reply), class: "btn btn-danger btn-sm", method: :delete, remote: true,
+          data: {confirm: "削除してよろしいですか？"} %> 
+    <% end %>
+    <div id="reply-show-<%= i %>">
+      <%= render "/projects/message_replys/message_reply_show", reply: reply %>
+    </div>
+    <br/>
+  <% end %>
+</details>
+<hr>

--- a/app/views/projects/message_replys/_message_reply_show.html.erb
+++ b/app/views/projects/message_replys/_message_reply_show.html.erb
@@ -1,0 +1,29 @@
+<div class="reply-text">
+  <!-- 返信本文 -->
+  <p><%= reply.reply_content %></p>
+</div>
+<!-- 添付画像 -->
+<% if reply.images.count > 0 %>
+  <details open>
+    <summary>
+      <font size="1"><%= reply.images.count %>個の画像</font>
+    </summary>
+    <% reply.images.each do |image| %>
+      <div class="reply-image-containar">
+        <%= link_to image_tag(image, class: "thumbnail"), 
+            show_image_user_project_message_message_reply_path(@user,@project,@message, image_id: image.id),
+            remote: true %>
+
+        <% if reply.poster_id == current_user.id %>
+          <div class="reply-image-menu">
+            <%= link_to "削除", delete_image_user_project_message_message_reply_path(@user,@project,@message, image_id: image.id), method: :delete, remote: true,
+                data: {confirm: "削除してよろしいですか？"} %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </details>
+<% end %>
+
+ <!-- モーダルウィンドウ表示 -->
+<div id="show_image" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>

--- a/app/views/projects/message_replys/_show_image.html.erb
+++ b/app/views/projects/message_replys/_show_image.html.erb
@@ -1,0 +1,12 @@
+<div class="modal-dialog modal-lg modal-dialog-center">
+  <div class="modal-content">
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <span aria-hidden="true">×</span>
+      </button>
+    </div>
+    <div class="modal-body text-center">
+      <%= image_tag @image, class: "reply-image-modal" %>
+    </div>
+  </div>
+</div>

--- a/app/views/projects/message_replys/cancel.js.erb
+++ b/app/views/projects/message_replys/cancel.js.erb
@@ -1,0 +1,1 @@
+$("#reply-show-<%= @index %>").html("<%= escape_javascript(render 'message_reply_show.html', reply: @reply) %>");

--- a/app/views/projects/message_replys/edit.js.erb
+++ b/app/views/projects/message_replys/edit.js.erb
@@ -1,0 +1,1 @@
+$("#reply-show-<%= @index %>").html("<%= escape_javascript(render 'message_reply_edit.html') %>");

--- a/app/views/projects/message_replys/show_image.js.erb
+++ b/app/views/projects/message_replys/show_image.js.erb
@@ -1,0 +1,2 @@
+$("#show_image").html("<%= escape_javascript(render 'show_image') %>");
+$("#show_image").modal("show");

--- a/app/views/projects/messages/show.html.erb
+++ b/app/views/projects/messages/show.html.erb
@@ -20,7 +20,19 @@
       </div>  
     </div>
   </div>
+  <div class="text-right mr-4">
+    <%= link_to "返信する", anchor: "reply_form" %>
+  </div>
 </div>
 <div class="text-center">
   <%= link_to '戻る', user_project_messages_path(@user,@project),class: "btn btn-light btn-outline-secontary col-2 " %>
+</div>
+
+<div class="col-6 offset-3 p-4">  
+  <!-- 返信一覧の表示 -->
+  <% if @message_replies.size > 0 %>
+    <%= render "/projects/message_replys/message_reply_list" %>
+  <% end %>
+  <!-- 返信フォームの表示 -->
+  <%= render "/projects/message_replys/message_reply_form" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,13 @@ Rails.application.routes.draw do
           member do
             patch 'read'
           end
+          resources :message_replys, only: %i[edit create update destroy] do
+            member do
+              get 'cancel'
+              get 'show_image'
+              delete 'delete_image'
+            end
+          end
         end
         resources :counselings do
           member do

--- a/db/migrate/20231204002627_create_message_replies.rb
+++ b/db/migrate/20231204002627_create_message_replies.rb
@@ -1,0 +1,12 @@
+class CreateMessageReplies < ActiveRecord::Migration[5.2]
+  def change
+    create_table :message_replies do |t|
+      t.text :reply_content, null: false, default: ''   # 返信本文
+      t.references :message, foreign_key: true          # 連絡ID
+      t.integer :poster_id, null: false                 # 投稿者ID
+      t.string :poster_name, null: false                # 投稿者名
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_13_074415) do
+ActiveRecord::Schema.define(version: 2023_12_04_002627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -128,6 +128,16 @@ ActiveRecord::Schema.define(version: 2023_11_13_074415) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["message_id"], name: "index_message_confirmers_on_message_id"
+  end
+
+  create_table "message_replies", force: :cascade do |t|
+    t.text "reply_content", default: "", null: false
+    t.bigint "message_id"
+    t.integer "poster_id", null: false
+    t.string "poster_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["message_id"], name: "index_message_replies_on_message_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -314,6 +324,7 @@ ActiveRecord::Schema.define(version: 2023_11_13_074415) do
   add_foreign_key "delegations", "projects"
   add_foreign_key "formats", "projects"
   add_foreign_key "message_confirmers", "messages"
+  add_foreign_key "message_replies", "messages"
   add_foreign_key "messages", "projects"
   add_foreign_key "project_users", "projects"
   add_foreign_key "project_users", "users"


### PR DESCRIPTION
### 概要
・連絡の返信機能追加（CRUD処理）
・連絡返信の画像添付機能追加

### タスク
- [ ] なし
- [x] あり   ⇨  詳細設計：[機能分類 No.219〜226](https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit#gid=1075510033&range=A215)
### 実装内容・手法
【実装内容】
・連絡詳細画面の下部に、『返信フォーム』、『返信一覧』の表示を追加。

【実装手法】
・基本的に、「報告返信機能」と同じ構成で実装。
・連絡返信のCRUD処理を追加。
　⇨ 連絡返信用のルーティング、コントローラをそれぞれ新規追加。
・連絡返信用のモデル(MessageReply)を追加。内容は[【テーブル定義書】：連絡返信](https://docs.google.com/spreadsheets/d/1PdVq0X0kNAhsJy8fFiE4-KQIAIt9u1qVTkh9CWllLww/edit#gid=2006939799&range=A1:B2) を参照。
・Active Storageを用いた画像添付機能の実装
⇨ 連絡返信時に画像を添付できる機能を追加（複数添付可能）
⇨ Active StorageのDBテーブルは、「報告返信」のタスクにて追加済みのため、今回は対応不要。
⇨ file_fieldで複数画像を選択した際のFile_Listオブジェクトは、読み取り専用であるため、返信投稿前の画像プレビュー取り消しを行なっても、画面の表示だけが削除されるのみで、File_Listオブジェクトの中身の一部削除が出来ない。
そこで、画像プレビューとFile_Listオブジェクトを紐付けるためのデータリスト『image_enable（画像の使用有無）』を設けて、hidden_fieldとして送信 ⇨ コントローラー側でそのデータを参照 ⇨ 添付画像の要不要を判定し、必要な画像のみDBへ保存する。
・リファクタリング
⇨ 一部、報告返信のメソッドをbase_project_controller.rb に移動し、報告返信と連絡返信で処理を共通化。

### 実装画像などあれば添付する
 [【画面設計書】返信機能 ]( https://docs.google.com/spreadsheets/d/1zZuioWUIBcg-FuWLLUdkpbVa4anMRSBjtn2VGlLcIsM/edit#gid=1132669412&range=A1)

### gemfileの変更
- [x] なし
- [ ] あり 
