### PR TITLE
相談返信機能の追加

### DIFF
--- a/.rubocop_todo1.yml
+++ b/.rubocop_todo1.yml
@@ -128,6 +128,7 @@ Rails/I18nLocaleTexts:
     - 'app/controllers/formats/report_formats_controller.rb'
     - 'app/controllers/projects/base_project_controller.rb'
     - 'app/controllers/projects/counselings_controller.rb'
+    - 'app/controllers/projects/counseling_replys_controller.rb'
     - 'app/controllers/projects/members_controller.rb'
     - 'app/controllers/projects/messages_controller.rb'
     - 'app/controllers/projects/message_replys_controller.rb'

--- a/app/controllers/projects/counseling_replys_controller.rb
+++ b/app/controllers/projects/counseling_replys_controller.rb
@@ -1,0 +1,70 @@
+class Projects::CounselingReplysController < Projects::BaseProjectController
+  before_action :project_authorization, only: %i[edit create update destroy cancel delete_image]
+
+  def edit
+    @counseling = Counseling.find(params[:counseling_id])
+    @reply = CounselingReply.find(params[:id])
+    @index = params[:index]
+  end
+
+  def create
+    @counseling = Counseling.find(params[:counseling_id])
+    unless params[:counseling_reply][:images].nil?
+      set_enable_images(params[:counseling_reply][:image_enable], params[:counseling_reply][:images])
+    end
+    @reply = @counseling.counseling_replies.new(counseling_reply_params)
+    if @reply.save
+      flash[:success] = '返信を投稿しました。'
+    else
+      flash[:danger] = '返信の投稿に失敗しました。'
+    end
+    redirect_to user_project_counseling_path(@user, @project, @counseling)
+  end
+
+  def update
+    @counseling = Counseling.find(params[:counseling_id])
+    @reply = CounselingReply.find(params[:id])
+    if @reply.update(counseling_reply_params)
+      flash[:success] = "返信内容を更新しました。"
+    else
+      flash[:danger] = "返信の更新に失敗しました。"
+    end
+    redirect_to user_project_counseling_path(@user, @project, @counseling)
+  end
+
+  def destroy
+    @counseling = Counseling.find(params[:counseling_id])
+    @reply = CounselingReply.find(params[:id])
+    @reply.images.purge  # 返信に紐づく画像データの削除
+    if @reply.destroy
+      flash[:success] = "返信を削除しました。"
+    else
+      flash[:danger] = "返信の削除に失敗しました。"
+    end
+    redirect_to user_project_counseling_path(@user, @project, @counseling)
+  end
+
+  def cancel
+    @counseling = Counseling.find(params[:counseling_id])
+    @reply = CounselingReply.find(params[:id])
+    @index = params[:index]
+  end
+
+  def show_image
+    @image = ActiveStorage::Attachment.find(params[:image_id])
+  end
+
+  def delete_image
+    @counseling = Counseling.find(params[:counseling_id])
+    @image = ActiveStorage::Attachment.find(params[:image_id])
+    @image.purge
+    flash[:success] = "画像を削除しました。"
+    redirect_to user_project_counseling_path(@user, @project, @counseling)
+  end
+
+  private
+
+  def counseling_reply_params
+    params.require(:counseling_reply).permit(:reply_content, :poster_name, :poster_id, images: [])
+  end
+end

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -11,7 +11,8 @@ class Projects::CounselingsController < Projects::BaseProjectController
   def show
     set_project_and_members
     @counseling = Counseling.find_by(id: params[:id])
-
+    @reply = @counseling.counseling_replies.new
+    @counseling_replies = @counseling.counseling_replies.all.order(:created_at)
     if @counseling.nil?
       flash[:alert] = "相談は削除されました。"
       redirect_to user_project_counselings_path(@user, @project) # または適切なパスに変更

--- a/app/controllers/projects/message_replys_controller.rb
+++ b/app/controllers/projects/message_replys_controller.rb
@@ -8,28 +8,28 @@ class Projects::MessageReplysController < Projects::BaseProjectController
   end
 
   def create
-    @@message = Message.find(params[:message_id])
+    @message = Message.find(params[:message_id])
     unless params[:message_reply][:images].nil?
       set_enable_images(params[:message_reply][:image_enable], params[:message_reply][:images])
     end
-    @reply = @@message.message_replies.new(message_reply_params)
+    @reply = @message.message_replies.new(message_reply_params)
     if @reply.save
       flash[:success] = '返信を投稿しました。'
     else
       flash[:danger] = '返信の投稿に失敗しました。'
     end
-    redirect_to user_project_message_path(@user, @project, @@message)
+    redirect_to user_project_message_path(@user, @project, @message)
   end
 
   def update
-    @@message = Message.find(params[:message_id])
+    @message = Message.find(params[:message_id])
     @reply = MessageReply.find(params[:id])
     if @reply.update(message_reply_params)
       flash[:success] = "返信内容を更新しました。"
     else
       flash[:danger] = "返信の更新に失敗しました。"
     end
-    redirect_to user_project_message_path(@user, @project, @@message)
+    redirect_to user_project_message_path(@user, @project, @message)
   end
 
   def destroy

--- a/app/models/counseling.rb
+++ b/app/models/counseling.rb
@@ -1,6 +1,7 @@
 class Counseling < ApplicationRecord
   belongs_to :project
   has_many :counseling_confirmers, dependent: :destroy
+  has_many :counseling_replies, dependent: :destroy
 
   attr_accessor :send_to
 

--- a/app/models/counseling_reply.rb
+++ b/app/models/counseling_reply.rb
@@ -1,0 +1,6 @@
+class CounselingReply < ApplicationRecord
+  belongs_to :counseling
+  has_many_attached :images, dependent: :destroy
+
+  validates :reply_content, presence: true
+end

--- a/app/views/projects/counseling_replys/_counseling_reply_edit.html.erb
+++ b/app/views/projects/counseling_replys/_counseling_reply_edit.html.erb
@@ -1,0 +1,6 @@
+<%= form_with(model: @reply, url: user_project_counseling_counseling_reply_path(@user,@project,@counseling,@reply), method: :patch) do |f| %>
+  <!-- 返信本文 -->
+  <%= f.text_area :reply_content,class: "textlines", rows: "3", required: true %>
+  <%= f.submit "更新する", class: "btn btn-primary btn-sm" %>
+  <%= link_to "キャンセル", cancel_user_project_counseling_counseling_reply_path(@user,@project,@counseling,@reply, index: @index), class: "btn btn-secondary btn-sm", remote: true %>
+<% end %>

--- a/app/views/projects/counseling_replys/_counseling_reply_form.html.erb
+++ b/app/views/projects/counseling_replys/_counseling_reply_form.html.erb
@@ -1,0 +1,26 @@
+<div class="col-12 container box-message-format-new pb-2 my-5">
+	<label id="reply_form" class="font-weight-bold message-title-box"><font size="3">返信フォーム</font></label>
+	
+	<%= form_with(model: @reply, url: user_project_counseling_counseling_replys_path(@user,@project,@counseling), method: :post) do |f| %>
+		<!-- 返信本文 -->
+		<%= f.text_area :reply_content, class: "col-11 form-control message-area mb-3", rows: "6", placeholder: "返信する…", required: true %>
+		<!-- 画像選択 -->
+		<label class="reply-image-label">
+			<span class="btn btn-light"><font size="2">📁画像アップロード</font></span>
+			<%= f.file_field :images, multiple: true, accept: 'image/*', class: "reply-image-form", onchange: "preview_images(this)" %>
+		</label>
+		<div class="images_area">
+			<!-- プレビュー画像が表示される -->
+		</div>
+		<!-- 画像使用有無 -->
+		<%= f.hidden_field :image_enable, id: "hiddenInput", :value => "" %>
+		<!-- 投稿者名 -->
+		<%= f.hidden_field :poster_name, :value => current_user.name %>
+		<!-- 投稿者ID -->
+		<%= f.hidden_field :poster_id, :value => current_user.id %>
+		<!-- 返信投稿 -->
+		<div class="text-center mr-4">
+			<%= f.submit "投稿する", class: "btn btn-light btn-outline-orange" %>
+		</div>
+	<% end %>
+</div>

--- a/app/views/projects/counseling_replys/_counseling_reply_list.html.erb
+++ b/app/views/projects/counseling_replys/_counseling_reply_list.html.erb
@@ -1,0 +1,22 @@
+<hr>
+<details>
+  <summary>
+    <u><%= @counseling_replies.size %>件の返信</u>
+  </summary>
+  <hr>
+  <% @counseling_replies.each_with_index do |reply, i| %>
+    <!-- 投稿者名 -->
+    👤<b><%= reply.poster_name %></b>
+    <font size="1"><%= l(reply.updated_at, format: :posting) %></font>
+    <% if reply.poster_id == current_user.id %>
+      <%= link_to "編集する", edit_user_project_counseling_counseling_reply_path(@user,@project,@counseling,reply,index: i ), class: "btn btn-primary btn-sm", remote: true %>
+      <%= link_to "削除する", user_project_counseling_counseling_reply_path(@user,@project,@counseling,reply), class: "btn btn-danger btn-sm", method: :delete, remote: true,
+          data: {confirm: "削除してよろしいですか？"} %> 
+    <% end %>
+    <div id="reply-show-<%= i %>">
+      <%= render "/projects/counseling_replys/counseling_reply_show", reply: reply %>
+    </div>
+    <br/>
+  <% end %>
+</details>
+<hr>

--- a/app/views/projects/counseling_replys/_counseling_reply_show.html.erb
+++ b/app/views/projects/counseling_replys/_counseling_reply_show.html.erb
@@ -1,0 +1,29 @@
+<div class="reply-text">
+  <!-- 返信本文 -->
+  <p><%= reply.reply_content %></p>
+</div>
+<!-- 添付画像 -->
+<% if reply.images.count > 0 %>
+  <details open>
+    <summary>
+      <font size="1"><%= reply.images.count %>個の画像</font>
+    </summary>
+    <% reply.images.each do |image| %>
+      <div class="reply-image-containar">
+        <%= link_to image_tag(image, class: "thumbnail"), 
+            show_image_user_project_counseling_counseling_reply_path(@user,@project,@counseling, image_id: image.id),
+            remote: true %>
+
+        <% if reply.poster_id == current_user.id %>
+          <div class="reply-image-menu">
+            <%= link_to "削除", delete_image_user_project_counseling_counseling_reply_path(@user,@project,@counseling, image_id: image.id), method: :delete, remote: true,
+                data: {confirm: "削除してよろしいですか？"} %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </details>
+<% end %>
+
+ <!-- モーダルウィンドウ表示 -->
+<div id="show_image" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>

--- a/app/views/projects/counseling_replys/_show_image.html.erb
+++ b/app/views/projects/counseling_replys/_show_image.html.erb
@@ -1,0 +1,12 @@
+<div class="modal-dialog modal-lg modal-dialog-center">
+  <div class="modal-content">
+    <div class="modal-header">
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <span aria-hidden="true">×</span>
+      </button>
+    </div>
+    <div class="modal-body text-center">
+      <%= image_tag @image, class: "reply-image-modal" %>
+    </div>
+  </div>
+</div>

--- a/app/views/projects/counseling_replys/cancel.js.erb
+++ b/app/views/projects/counseling_replys/cancel.js.erb
@@ -1,0 +1,1 @@
+$("#reply-show-<%= @index %>").html("<%= escape_javascript(render 'counseling_reply_show.html', reply: @reply) %>");

--- a/app/views/projects/counseling_replys/edit.js.erb
+++ b/app/views/projects/counseling_replys/edit.js.erb
@@ -1,0 +1,1 @@
+$("#reply-show-<%= @index %>").html("<%= escape_javascript(render 'counseling_reply_edit.html') %>");

--- a/app/views/projects/counseling_replys/show_image.js.erb
+++ b/app/views/projects/counseling_replys/show_image.js.erb
@@ -1,0 +1,2 @@
+$("#show_image").html("<%= escape_javascript(render 'show_image') %>");
+$("#show_image").modal("show");

--- a/app/views/projects/counselings/show.html.erb
+++ b/app/views/projects/counselings/show.html.erb
@@ -18,7 +18,19 @@
       </div>  
     </div>
   </div>
+  <div class="text-right mr-4">
+    <%= link_to "返信する", anchor: "reply_form" %>
+  </div>
 </div>
 <div class="text-center">
   <%= link_to '戻る', user_project_messages_path(@user,@project),class: "btn btn-light btn-outline-secontary col-2 " %>
+</div>
+
+<div class="col-6 offset-3 p-4">  
+  <!-- 返信一覧の表示 -->
+  <% if @counseling_replies.size > 0 %>
+    <%= render "/projects/counseling_replys/counseling_reply_list" %>
+  <% end %>
+  <!-- 返信フォームの表示 -->
+  <%= render "/projects/counseling_replys/counseling_reply_form" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,13 @@ Rails.application.routes.draw do
           member do
             patch 'read'
           end
+          resources :counseling_replys, only: %i[edit  create update destroy] do
+            member do
+              get 'cancel'
+              get 'show_image'
+              delete 'delete_image'
+            end
+          end
         end
         resources :reports do
           member do

--- a/db/migrate/20231206133420_create_counseling_replies.rb
+++ b/db/migrate/20231206133420_create_counseling_replies.rb
@@ -1,0 +1,12 @@
+class CreateCounselingReplies < ActiveRecord::Migration[5.2]
+  def change
+    create_table :counseling_replies do |t|
+      t.text :reply_content, null: false, default: ''   # 返信本文
+      t.references :counseling, foreign_key: true       # 相談ID
+      t.integer :poster_id, null: false                 # 投稿者ID
+      t.string :poster_name, null: false                # 投稿者名
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,8 +93,8 @@ ActiveRecord::Schema.define(version: 2023_12_07_000217) do
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-        t.index ["project_id"], name: "index_counselings_on_project_id"
-      end
+    t.index ["project_id"], name: "index_counselings_on_project_id"
+  end
 
   create_table "date_fields", force: :cascade do |t|
     t.string "label_name", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_04_002627) do
+ActiveRecord::Schema.define(version: 2023_12_07_000217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,16 @@ ActiveRecord::Schema.define(version: 2023_12_04_002627) do
     t.index ["counseling_id"], name: "index_counseling_confirmers_on_counseling_id"
   end
 
+  create_table "counseling_replies", force: :cascade do |t|
+    t.text "reply_content", default: "", null: false
+    t.bigint "counseling_id"
+    t.integer "poster_id", null: false
+    t.string "poster_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["counseling_id"], name: "index_counseling_replies_on_counseling_id"
+  end
+
   create_table "counselings", force: :cascade do |t|
     t.text "counseling_detail", default: "", null: false
     t.date "counseling_reply_deadline"
@@ -83,8 +93,8 @@ ActiveRecord::Schema.define(version: 2023_12_04_002627) do
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["project_id"], name: "index_counselings_on_project_id"
-  end
+        t.index ["project_id"], name: "index_counselings_on_project_id"
+      end
 
   create_table "date_fields", force: :cascade do |t|
     t.string "label_name", default: "", null: false
@@ -319,6 +329,7 @@ ActiveRecord::Schema.define(version: 2023_12_04_002627) do
   add_foreign_key "check_box_option_strings", "check_boxes"
   add_foreign_key "check_boxes", "questions"
   add_foreign_key "counseling_confirmers", "counselings"
+  add_foreign_key "counseling_replies", "counselings"
   add_foreign_key "counselings", "projects"
   add_foreign_key "date_fields", "questions"
   add_foreign_key "delegations", "projects"


### PR DESCRIPTION
### 概要
・相談の返信機能追加（CRUD処理）
・相談返信の画像添付機能追加
・連絡返信コントローラー(message_replys_controller.rb)の警告修正

### タスク
- [ ] なし
- [x] あり   ⇨  詳細設計：[機能分類 No.227〜234](https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit#gid=1075510033&range=A223)
### 実装内容・手法
【実装内容】
・相談詳細画面の下部に、『返信フォーム』、『返信一覧』の表示を追加。

【実装手法】
・基本的に、「報告返信機能」「連絡返信機能」と同じ構成で実装。
・相談返信のCRUD処理を追加。
　⇨ 相談返信用のルーティング、コントローラをそれぞれ新規追加。
・相談返信用のモデル(CounselingReply)を追加。内容は以下を参照。
　⇨ [【テーブル定義書】：ER図](https://docs.google.com/spreadsheets/d/1PdVq0X0kNAhsJy8fFiE4-KQIAIt9u1qVTkh9CWllLww/edit#gid=1073968477&range=A1)
　⇨ [【テーブル定義書】：連絡返信](https://docs.google.com/spreadsheets/d/1PdVq0X0kNAhsJy8fFiE4-KQIAIt9u1qVTkh9CWllLww/edit#gid=1144557642&range=A1:B2)
・Active Storageを用いた画像添付機能の実装
⇨ 相談返信時に画像を添付できる機能を追加（複数添付可能）
⇨ Active StorageのDBテーブルは、「報告返信」のタスクにて追加済みのため、今回は対応不要。
⇨ file_fieldで複数画像を選択した際のFile_Listオブジェクトは、読み取り専用であるため、返信投稿前の画像プレビュー取り消しを行なっても、画面の表示だけが削除されるのみで、File_Listオブジェクトの中身の一部削除が出来ない。
そこで、画像プレビューとFile_Listオブジェクトを紐付けるためのデータリスト『image_enable（画像の使用有無）』を設けて、hidden_fieldとして送信 ⇨ コントローラー側でそのデータを参照 ⇨ 添付画像の要不要を判定し、必要な画像のみDBへ保存する。

・リファクタリング
⇨ 連絡返信のコントローラー(message_replys_controller.rb)にて、誤ってクラス変数(@@message)を使用していたのをインスタンス変数(@message)に修正。

### 実装画像などあれば添付する
 [【画面設計書】返信機能 ]( https://docs.google.com/spreadsheets/d/1zZuioWUIBcg-FuWLLUdkpbVa4anMRSBjtn2VGlLcIsM/edit#gid=1132669412&range=A1)

### gemfileの変更
- [x] なし
- [ ] あり 
