### PR TITLE
Refactor/counseling notification

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -125,3 +125,8 @@ Rails/Output:
 #RuboCopを実行した際にRails/UniqueValidationWithoutIndex Cop（RuboCopのルールの一つ）に関するエラーを無効化
 Rails/UniqueValidationWithoutIndex:
   Enabled: false
+
+#ActiveRecord::Schema.defineブロックが設定された行数の上限を超過していることによるエラーを無効化
+Metrics/BlockLength:
+  Exclude:
+    - 'db/schema.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -121,4 +121,7 @@ Rails/LexicallyScopedActionFilter:
 #putsやprintなどの出力はRailsのロガーを使わなければいけない設定を無効にする
 Rails/Output:
   Enabled: false
-  
+
+#RuboCopを実行した際にRails/UniqueValidationWithoutIndex Cop（RuboCopのルールの一つ）に関するエラーを無効化
+Rails/UniqueValidationWithoutIndex:
+  Enabled: false

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,30 @@
 class ApplicationController < ActionController::Base
+  before_action :store_user_location!, if: :storable_location?
+
+  def store_user_location!
+    store_location_for(:user, request.fullpath)
+  end
+
+  def storable_location?
+    request.get? && !devise_controller? && !request.xhr? && !root_path.match(/\/users/)
+  end
+
+  def store_location_for(resource_or_scope, location)
+    session[:"#{resource_or_scope}_return_to"] = location
+  end
+
+  def user_has_access?(user, path)
+    counseling_id = extract_counseling_id_from_path(path)
+    return false unless counseling_id
+  
+    counseling = Counseling.find_by(id: counseling_id)
+    return false unless counseling
+  
+    counseling.project.users.include?(user)
+  end
+
+  def extract_counseling_id_from_path(path)
+    match = path.match(/counselings\/(\d+)/)
+    match[1] if match
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   end
 
   def storable_location?
-    request.get? && !devise_controller? && !request.xhr? && !root_path.match(/\/users/)
+    request.get? && !devise_controller? && !request.xhr? && root_path.exclude?('/users')
   end
 
   def store_location_for(resource_or_scope, location)
@@ -16,10 +16,10 @@ class ApplicationController < ActionController::Base
   def user_has_access?(user, path)
     counseling_id = extract_counseling_id_from_path(path)
     return false unless counseling_id
-  
+
     counseling = Counseling.find_by(id: counseling_id)
     return false unless counseling
-  
+
     counseling.project.users.include?(user)
   end
 

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -39,7 +39,6 @@ class Projects::CounselingsController < Projects::BaseProjectController
     @counseling = @project.counselings.new(counseling_params)
     @counseling.sender_id = current_user.id
     @counseling.sender_name = current_user.name
-    @counseling.token = SecureRandom.hex(10)
     # ActiveRecord::Type::Boolean：値の型をboolean型に変更
     if ActiveRecord::Type::Boolean.new.cast(params[:counseling][:send_to_all])
       # TO ALLが選択されている時
@@ -48,7 +47,7 @@ class Projects::CounselingsController < Projects::BaseProjectController
           @send = @counseling.counseling_confirmers.new(counseling_confirmer_id: member.id)
           @send.save
           @user = member
-          CounselingMailer.notification(@user, @counseling, @project, @counseling.token).deliver_now
+          CounselingMailer.notification(@user, @counseling, @project).deliver_now
         end
         flash[:success] = "相談内容を送信しました。"
         redirect_to user_project_path current_user, params[:project_id]
@@ -63,7 +62,7 @@ class Projects::CounselingsController < Projects::BaseProjectController
           @send = @counseling.counseling_confirmers.new(counseling_confirmer_id: t)
           @send.save
           @user = User.find(t)
-          CounselingMailer.notification(@user, @counseling, @project, @counseling.token).deliver_now
+          CounselingMailer.notification(@user, @counseling, @project).deliver_now
         end
         flash[:success] = "相談内容を送信しました。"
         redirect_to user_project_path current_user, params[:project_id]
@@ -156,7 +155,7 @@ class Projects::CounselingsController < Projects::BaseProjectController
     recipients = @counseling.send_to_all ? @members : @counseling.send_to
     recipients.each do |recipient|
       recipient = recipient.is_a?(User) ? recipient : User.find(recipient)
-      CounselingMailer.notification_edited(recipient, @counseling, @project, @counseling.token).deliver_now
+      CounselingMailer.notification_edited(recipient, @counseling, @project).deliver_now
     end
   end
 end

--- a/app/controllers/users/base_user_controller.rb
+++ b/app/controllers/users/base_user_controller.rb
@@ -18,15 +18,22 @@ class Users::BaseUserController < BaseController
     redirect_to root_path
   end
 
-  # ログイン済みユーザーを許可
   def correct_user
     @user = if params[:user_id].present?
               User.find(params[:user_id])
             else
               User.find(params[:id])
             end
+  
     return if current_user?(@user)
-
+  
+    counseling_id = params[:counseling_id] || params[:id]
+    counseling = Counseling.find_by(id: counseling_id)
+  
+    if counseling && counseling.project.users.include?(current_user)
+      return
+    end
+  
     flash[:danger] = t('flash.not_logined')
     redirect_to root_path
   end

--- a/app/controllers/users/base_user_controller.rb
+++ b/app/controllers/users/base_user_controller.rb
@@ -24,16 +24,16 @@ class Users::BaseUserController < BaseController
             else
               User.find(params[:id])
             end
-  
+
     return if current_user?(@user)
-  
+
     counseling_id = params[:counseling_id] || params[:id]
     counseling = Counseling.find_by(id: counseling_id)
-  
+
     if counseling && counseling.project.users.include?(current_user)
       return
     end
-  
+
     flash[:danger] = t('flash.not_logined')
     redirect_to root_path
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -75,14 +75,14 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   # ユーザー新規登録後のリダイレクト先を参加しているプロジェクト一覧ページに変更
-  #def after_sign_in_path_for(resource)
-    #user_projects_path(resource)
-  #end
+  # def after_sign_in_path_for(resource)
+  # user_projects_path(resource)
+  # end
 
   def after_sign_in_path_for(resource)
     stored_location = session[:user_return_to]
     session.delete(:user_return_to)
-    
+
     if stored_location && user_has_access?(resource, stored_location)
       stored_location
     else

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -75,7 +75,18 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   # ユーザー新規登録後のリダイレクト先を参加しているプロジェクト一覧ページに変更
+  #def after_sign_in_path_for(resource)
+    #user_projects_path(resource)
+  #end
+
   def after_sign_in_path_for(resource)
-    user_projects_path(resource)
+    stored_location = session[:user_return_to]
+    session.delete(:user_return_to)
+    
+    if stored_location && user_has_access?(resource, stored_location)
+      stored_location
+    else
+      user_projects_path(resource)
+    end
   end
 end

--- a/app/mailers/counseling_mailer.rb
+++ b/app/mailers/counseling_mailer.rb
@@ -1,9 +1,8 @@
 class CounselingMailer < ApplicationMailer
-  def notification(user, counseling, project, token)
+  def notification(user, counseling, project)
     @user = user
     @counseling = counseling
     @project = project
-    @token = token
     @project_name = project.name
     @sender_name = User.find(@counseling.sender_id).name
     @counseling_title = counseling.title
@@ -11,11 +10,10 @@ class CounselingMailer < ApplicationMailer
     mail(to: @user.email, subject: I18n.t('counseling_mailer.consultation_arrived'))
   end
 
-  def notification_edited(user, counseling, project, token)
+  def notification_edited(user, counseling, project)
     @user = user
     @counseling = counseling
     @project = project
-    @token = token
     @project_name = project.name
     @sender_name = User.find(@counseling.sender_id).name
     @counseling_title = counseling.title

--- a/app/views/counseling_mailer/notification.html.erb
+++ b/app/views/counseling_mailer/notification.html.erb
@@ -2,4 +2,4 @@
 
 <h2><%= "#{@sender_name}さんから相談がありました。" %></h2>
 <p>下記のリンクより確認できます。</p>
-<%= link_to @counseling_title, user_project_counseling_url(@user, @project, @counseling, token: @token) %>
+<%= link_to @counseling_title, user_project_counseling_url(@user, @project, @counseling) %>

--- a/app/views/counseling_mailer/notification_edited.html.erb
+++ b/app/views/counseling_mailer/notification_edited.html.erb
@@ -2,4 +2,4 @@
 
 <h2><%= @sender_name %>さんからの相談内容が更新されました。</h2>
 <p>下記のリンクより確認できます。</p>
-<p><%= link_to @counseling_title, user_project_counseling_url(@user, @project, @counseling, token: @token) %></p>
+<p><%= link_to @counseling_title, user_project_counseling_url(@user, @project, @counseling) %></p>

--- a/app/views/projects/counselings/show.html.erb
+++ b/app/views/projects/counselings/show.html.erb
@@ -20,5 +20,5 @@
   </div>
 </div>
 <div class="text-center">
-  <%= link_to '戻る', user_project_messages_path(@user,@project),class: "btn btn-light btn-outline-secontary col-2 " %>
+  <%= link_to '戻る', user_project_counselings_path(@user,@project),class: "btn btn-light btn-outline-secontary col-2 " %>
 </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_28_105034) do
+ActiveRecord::Schema.define(version: 2023_12_07_121602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,16 +55,14 @@ ActiveRecord::Schema.define(version: 2023_10_28_105034) do
 
   create_table "counselings", force: :cascade do |t|
     t.text "counseling_detail", default: "", null: false
-    t.date "counseling_reply_deadline"
+    t.date "counseling_reply_deadline"n
     t.bigint "project_id"
     t.integer "sender_id"
     t.string "sender_name"
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "token"
     t.index ["project_id"], name: "index_counselings_on_project_id"
-    t.index ["token"], name: "index_counselings_on_token", unique: true
   end
 
   create_table "date_fields", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_04_002627) do
-
+ActiveRecord::Schema.define(version: 2023_10_28_105034) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,7 +54,7 @@ ActiveRecord::Schema.define(version: 2023_12_04_002627) do
 
   create_table "counselings", force: :cascade do |t|
     t.text "counseling_detail", default: "", null: false
-    t.date "counseling_reply_deadline"n
+    t.date "counseling_reply_deadline"
     t.bigint "project_id"
     t.integer "sender_id"
     t.string "sender_name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_28_105034) do
+ActiveRecord::Schema.define(version: 2023_12_04_002627) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2023_12_04_002627) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_07_121602) do
+ActiveRecord::Schema.define(version: 2023_12_04_002627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
### 概要
①相談通知メールのリンクからログイン後に相談詳細画面へ遷移するよう修正
②counselingsのtokenカラムを削除
③相談詳細画面の戻るボタン押下で相談一覧画面へ遷移するよう修正

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
①相談通知メールのリンクからログイン後に相談詳細画面へ遷移するよう、フレンドリーフォワーディング機能追加
②プロジェクト内の全ての相談詳細画面はプロジェクトメンバーであれば閲覧可能なため、相談者、相談相手のみのアクセス制限は不要であることからtokenカラムは削除
③相談詳細画面の戻るボタンを押下すると連絡一覧画面へ遷移するため、相談一覧画面へ遷移するよう修正

### 実装画像などあれば添付する
https://docs.google.com/spreadsheets/d/1zZuioWUIBcg-FuWLLUdkpbVa4anMRSBjtn2VGlLcIsM/edit#gid=1887172196
### gemfileの変更
- [x] なし
- [ ] あり 
