### PR TITLE
ページネーションでのページ遷移不具合解消(相談一覧)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -110,9 +110,11 @@ Metrics/PerceivedComplexity:
   Max: 15
 
 #ブロック内の行数を最大値以下とする設定をspec/**/*は除外
+#ActiveRecord::Schema.defineブロックが設定された行数の上限を超過していることによるエラーを無効化
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+    - 'db/schema.rb'
 
 #befor_action等のonly、exceptオプションで指定されているメソッドが存在していなければならない設定を無効
 Rails/LexicallyScopedActionFilter:
@@ -125,8 +127,3 @@ Rails/Output:
 #RuboCopを実行した際にRails/UniqueValidationWithoutIndex Cop（RuboCopのルールの一つ）に関するエラーを無効化
 Rails/UniqueValidationWithoutIndex:
   Enabled: false
-
-#ActiveRecord::Schema.defineブロックが設定された行数の上限を超過していることによるエラーを無効化
-Metrics/BlockLength:
-  Exclude:
-    - 'db/schema.rb'

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -6,6 +6,10 @@ class Projects::CounselingsController < Projects::BaseProjectController
     @counselings = @project.counselings.all.order(created_at: 'DESC').page(params[:counselings_page]).per(5)
     you_addressee_counseling_ids = CounselingConfirmer.where(counseling_confirmer_id: @user.id).pluck(:counseling_id)
     @you_addressee_counselings = @project.counselings.where(id: you_addressee_counseling_ids).order(created_at: 'DESC').page(params[:you_addressee_counselings_page]).per(5)
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   def show

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -3,9 +3,9 @@ class Projects::CounselingsController < Projects::BaseProjectController
 
   def index
     set_project_and_members
-    @counselings = @project.counselings.all.order(created_at: 'DESC').page(params[:page]).per(5)
+    @counselings = @project.counselings.all.order(created_at: 'DESC').page(params[:counselings_page]).per(5)
     you_addressee_counseling_ids = CounselingConfirmer.where(counseling_confirmer_id: @user.id).pluck(:counseling_id)
-    @you_addressee_counselings = @project.counselings.where(id: you_addressee_counseling_ids).order(created_at: 'DESC').page(params[:page]).per(5)
+    @you_addressee_counselings = @project.counselings.where(id: you_addressee_counseling_ids).order(created_at: 'DESC').page(params[:you_addressee_counselings_page]).per(5)
   end
 
   def show

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -5,7 +5,11 @@ class Projects::CounselingsController < Projects::BaseProjectController
     set_project_and_members
     @counselings = @project.counselings.all.order(created_at: 'DESC').page(params[:counselings_page]).per(5)
     you_addressee_counseling_ids = CounselingConfirmer.where(counseling_confirmer_id: @user.id).pluck(:counseling_id)
-    @you_addressee_counselings = @project.counselings.where(id: you_addressee_counseling_ids).order(created_at: 'DESC').page(params[:you_addressee_counselings_page]).per(5)
+    @you_addressee_counselings = @project.counselings
+                                         .where(id: you_addressee_counseling_ids)
+                                         .order(created_at: 'DESC')
+                                         .page(params[:you_addressee_counselings_page])
+                                         .per(5)
     respond_to do |format|
       format.html
       format.js

--- a/app/helpers/projects/counselings_helper.rb
+++ b/app/helpers/projects/counselings_helper.rb
@@ -7,4 +7,13 @@ module Projects::CounselingsHelper
     svg['class'] = options[:class] if options[:class].present?
     doc.to_html.html_safe
   end
+
+  # タブごとのページ設定
+  def counseling_page(tab)
+    page = {
+      'you-addressee' => 'you_addressee_counselings_page',
+      'counseling' => 'counselings_page'
+    }
+    page[tab]
+  end
 end

--- a/app/views/projects/counselings/_all_counselings.html.erb
+++ b/app/views/projects/counselings/_all_counselings.html.erb
@@ -1,7 +1,7 @@
 <div class="box-counseling-index">
   <% if @counselings.present? %>
     <div class="d-flex justify-content-end mb-3">
-      <%= form_with url: "#", method: :get, remote: true do |form| %>
+      <%= form_with url: "#", method: :get, local: true do |form| %>
         <%= form.hidden_field :search_type, :value => "counseling" %>
         <%= form.label :search, "件名検索：", class: "mb-0" %>
         <%= form.text_field :search, placeholder: "キーワードを入力", class: "search-box" %>

--- a/app/views/projects/counselings/_all_counselings.html.erb
+++ b/app/views/projects/counselings/_all_counselings.html.erb
@@ -1,7 +1,7 @@
 <div class="box-counseling-index">
   <% if @counselings.present? %>
     <div class="d-flex justify-content-end mb-3">
-      <%= form_with url: "#", method: :get, local: true do |form| %>
+      <%= form_with url: "#", method: :get, remote: true do |form| %>
         <%= form.hidden_field :search_type, :value => "counseling" %>
         <%= form.label :search, "件名検索：", class: "mb-0" %>
         <%= form.text_field :search, placeholder: "キーワードを入力", class: "search-box" %>

--- a/app/views/projects/counselings/_all_counselings.html.erb
+++ b/app/views/projects/counselings/_all_counselings.html.erb
@@ -1,0 +1,61 @@
+<div class="box-counseling-index">
+  <% if @counselings.present? %>
+    <div class="d-flex justify-content-end mb-3">
+      <%= form_with url: "#", method: :get, local: true do |form| %>
+        <%= form.hidden_field :search_type, :value => "counseling" %>
+        <%= form.label :search, "件名検索：", class: "mb-0" %>
+        <%= form.text_field :search, placeholder: "キーワードを入力", class: "search-box" %>
+        <%= form.submit "検索", class: "btn btn-outline-orange" %>
+      <% end %>
+    </div>
+    <div class="table-header">
+      <div class="subject-name">
+        件名
+      </div>
+      <div class="counseling-date">
+        連絡日
+      </div>
+      <div class="counseling-person">
+        相談者
+      </div>
+      <div class="counseling-action">
+        アクション
+      </div>
+    </div>
+    <div class="table-body">
+      <% line_num = 0%>
+      <% @counselings.each do |counseling|%>
+        <% line_num += 1%>
+        <div class="table-line", data-project-index-line-num="<%="#{line_num}"%>">
+          <div class="subject-name">
+            <%= link_to counseling.title, user_project_counseling_path(@user, @project, counseling), class: "counseling-detail-link" %>
+          </div>
+          <div class="counseling-date">
+            <%= l(counseling.created_at, format: :long) %>
+          </div>
+          <div class="counseling-person">
+              <%= counseling.sender_name %>
+          </div>
+          <div class="counseling-action">
+            <% if counseling.sender_id == current_user.id %>
+              <%= link_to "編集", edit_user_project_counseling_path(@user, @project, counseling), class: "btn btn-outline-orange" %>
+              <%= link_to "削除", user_project_counseling_path(@user, @project, counseling), method: :delete, data: { confirm: "投稿された相談を削除してよろしいですか？" }, class: "btn btn-danger" %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else @counselings.blank?%>
+    <P>相談履歴がありません。</P>
+  <% end %>
+  <div class="d-flex">
+    <% if @counselings.present?%>
+      <div class="paginate">
+        <%= paginate @counselings, param_name: counseling_page('counseling'), remote: true %>
+      </div>
+    <% end %>
+    <div class="ml-auto">
+      <%= link_to "戻る", :back, class: "btn btn-secondary" %>
+    </div>
+  </div>
+</div>

--- a/app/views/projects/counselings/_you_addressee_counselings.html.erb
+++ b/app/views/projects/counselings/_you_addressee_counselings.html.erb
@@ -1,0 +1,59 @@
+<div class="box-you-addressee-index">
+  <% if @you_addressee_counselings.present? %>
+    <div class="d-flex justify-content-end mb-3">
+      <%= form_with url: "#", method: :get, local: true do |form| %>
+        <%= form.hidden_field :search_type, :value => "you-addressee" %>
+        <%= form.label :search, "件名検索：", class: "mb-0" %>
+        <%= form.text_field :search, placeholder: "キーワードを入力", class: "search-box" %>
+        <%= form.submit "検索", class: "btn btn-outline-orange" %>
+      <% end %>
+    </div>
+    <div class="table-header">
+      <div class="subject-name">
+        件名
+      </div>
+      <div class="counseling-date">
+        連絡日
+      </div>
+      <div class="counseling-person">
+        相談者
+      </div>
+      <!-- div class="counseling-action">
+        アクション
+      </div -->
+    </div>
+    <div class="table-body">
+      <% line_num = 0%>
+      <% @you_addressee_counselings.each do |counseling|%>
+        <% line_num += 1%>
+        <div class="table-line", data-project-index-line-num="<%="#{line_num}"%>">
+          <div class="subject-name">
+            <%= link_to counseling.title, user_project_counseling_path(@user, @project, counseling), class: "counseling-detail-link" %>
+          </div>
+          <div class="counseling-date">
+            <%= l(counseling.created_at, format: :long) %>
+          </div>
+          <div class="counseling-person">
+              <%= counseling.sender_name %>
+          </div>
+          <!-- div class="counseling-action">
+              <%#= link_to "編集", "#", class: "btn btn-outline-orange" %>
+              <%#= link_to "削除", "#", method: :delete, data: { confirm: "投稿された連絡を削除してよろしいですか？" }, class: "btn btn-danger" %>
+          </div -->
+        </div>
+      <% end %>
+    </div>
+  <% else @you_addressee_counselings.blank? %>
+    <P>あなた宛の相談履歴がありません。</P>
+  <% end %>
+  <div class="d-flex">
+    <% if @you_addressee_counselings.present?%>
+      <div class="paginate">
+        <%= paginate @you_addressee_counselings, param_name: counseling_page('you-addressee'), remote: true %>
+      </div>
+    <% end %>
+    <div class="ml-auto">
+      <%= link_to "戻る", :back, class: "btn btn-secondary" %>
+    </div>
+  </div>
+</div>

--- a/app/views/projects/counselings/_you_addressee_counselings.html.erb
+++ b/app/views/projects/counselings/_you_addressee_counselings.html.erb
@@ -1,7 +1,7 @@
 <div class="box-you-addressee-index">
   <% if @you_addressee_counselings.present? %>
     <div class="d-flex justify-content-end mb-3">
-      <%= form_with url: "#", method: :get, remote: true do |form| %>
+      <%= form_with url: "#", method: :get, local: true do |form| %>
         <%= form.hidden_field :search_type, :value => "you-addressee" %>
         <%= form.label :search, "件名検索：", class: "mb-0" %>
         <%= form.text_field :search, placeholder: "キーワードを入力", class: "search-box" %>

--- a/app/views/projects/counselings/_you_addressee_counselings.html.erb
+++ b/app/views/projects/counselings/_you_addressee_counselings.html.erb
@@ -1,7 +1,7 @@
 <div class="box-you-addressee-index">
   <% if @you_addressee_counselings.present? %>
     <div class="d-flex justify-content-end mb-3">
-      <%= form_with url: "#", method: :get, local: true do |form| %>
+      <%= form_with url: "#", method: :get, remote: true do |form| %>
         <%= form.hidden_field :search_type, :value => "you-addressee" %>
         <%= form.label :search, "件名検索：", class: "mb-0" %>
         <%= form.text_field :search, placeholder: "キーワードを入力", class: "search-box" %>

--- a/app/views/projects/counselings/index.html.erb
+++ b/app/views/projects/counselings/index.html.erb
@@ -80,7 +80,7 @@
             <div class="d-flex">
               <% if @you_addressee_counselings.present?%>
                 <div class="paginate">
-                  <%= paginate @you_addressee_counselings %>
+                  <%= paginate @you_addressee_counselings, param_name: counseling_page('you-addressee') %>
                 </div>
               <% end %>
               <div class="ml-auto">
@@ -144,7 +144,7 @@
             <div class="d-flex">
               <% if @counselings.present?%>
                 <div class="paginate">
-                  <%= paginate @counselings %>
+                  <%= paginate @counselings, param_name: counseling_page('counseling') %>
                 </div>
               <% end %>
               <div class="ml-auto">

--- a/app/views/projects/counselings/index.html.erb
+++ b/app/views/projects/counselings/index.html.erb
@@ -29,128 +29,14 @@
       <div class="tab-content" id="myTabContent">
         <!-- あなた宛の相談一覧 -->
         <div class="tab-pane fade show active" id="you-addressee" role="tabpanel" aria-labelledby="you-addressee-tab">
-          <div class="box-you-addressee-index">
-            <% if @you_addressee_counselings.present? %>
-              <div class="d-flex justify-content-end mb-3">
-                <%= form_with url: "#", method: :get, local: true do |form| %>
-                  <%= form.hidden_field :search_type, :value => "you-addressee" %>
-                  <%= form.label :search, "件名検索：", class: "mb-0" %>
-                  <%= form.text_field :search, placeholder: "キーワードを入力", class: "search-box" %>
-                  <%= form.submit "検索", class: "btn btn-outline-orange" %>
-                <% end %>
-              </div>
-              <div class="table-header">
-                <div class="subject-name">
-                  件名
-                </div>
-                <div class="counseling-date">
-                  連絡日
-                </div>
-                <div class="counseling-person">
-                  相談者
-                </div>
-                <!-- div class="counseling-action">
-                  アクション
-                </div -->
-              </div>
-              <div class="table-body">
-                <% line_num = 0%>
-                <% @you_addressee_counselings.each do |counseling|%>
-                  <% line_num += 1%>
-                  <div class="table-line", data-project-index-line-num="<%="#{line_num}"%>">
-                    <div class="subject-name">
-                      <%= link_to counseling.title, user_project_counseling_path(@user, @project, counseling), class: "counseling-detail-link" %>
-                    </div>
-                    <div class="counseling-date">
-                      <%= l(counseling.created_at, format: :long) %>
-                    </div>
-                    <div class="counseling-person">
-                        <%= counseling.sender_name %>
-                    </div>
-                    <!-- div class="counseling-action">
-                        <%#= link_to "編集", "#", class: "btn btn-outline-orange" %>
-                        <%#= link_to "削除", "#", method: :delete, data: { confirm: "投稿された連絡を削除してよろしいですか？" }, class: "btn btn-danger" %>
-                    </div -->
-                  </div>
-                <% end %>
-              </div>
-            <% else @you_addressee_counselings.blank? %>
-              <P>あなた宛の相談履歴がありません。</P>
-            <% end %>
-            <div class="d-flex">
-              <% if @you_addressee_counselings.present?%>
-                <div class="paginate">
-                  <%= paginate @you_addressee_counselings, param_name: counseling_page('you-addressee') %>
-                </div>
-              <% end %>
-              <div class="ml-auto">
-                <%= link_to "戻る", :back, class: "btn btn-secondary" %>
-              </div>
-            </div>
+          <div id="you-addressee-counselings-container">
+            <%= render partial: 'projects/counselings/you_addressee_counselings', locals: { counselings: @you_addressee_counselings } %>
           </div>
         </div>
         <!-- 全メンバーの連絡 -->
         <div class="tab-pane fade" id="counseling" role="tabpanel" aria-labelledby="counseling-tab">
-          <div class="box-counseling-index">
-            <% if @counselings.present? %>
-              <div class="d-flex justify-content-end mb-3">
-                <%= form_with url: "#", method: :get, local: true do |form| %>
-                  <%= form.hidden_field :search_type, :value => "counseling" %>
-                  <%= form.label :search, "件名検索：", class: "mb-0" %>
-                  <%= form.text_field :search, placeholder: "キーワードを入力", class: "search-box" %>
-                  <%= form.submit "検索", class: "btn btn-outline-orange" %>
-                <% end %>
-              </div>
-              <div class="table-header">
-                <div class="subject-name">
-                  件名
-                </div>
-                <div class="counseling-date">
-                  連絡日
-                </div>
-                <div class="counseling-person">
-                  相談者
-                </div>
-                <div class="counseling-action">
-                  アクション
-                </div>
-              </div>
-              <div class="table-body">
-                <% line_num = 0%>
-                <% @counselings.each do |counseling|%>
-                  <% line_num += 1%>
-                  <div class="table-line", data-project-index-line-num="<%="#{line_num}"%>">
-                    <div class="subject-name">
-                      <%= link_to counseling.title, user_project_counseling_path(@user, @project, counseling), class: "counseling-detail-link" %>
-                    </div>
-                    <div class="counseling-date">
-                      <%= l(counseling.created_at, format: :long) %>
-                    </div>
-                    <div class="counseling-person">
-                        <%= counseling.sender_name %>
-                    </div>
-                    <div class="counseling-action">
-                      <% if counseling.sender_id == current_user.id %>
-                        <%= link_to "編集", edit_user_project_counseling_path(@user, @project, counseling), class: "btn btn-outline-orange" %>
-                        <%= link_to "削除", user_project_counseling_path(@user, @project, counseling), method: :delete, data: { confirm: "投稿された相談を削除してよろしいですか？" }, class: "btn btn-danger" %>
-                      <% end %>
-                    </div>
-                  </div>
-                <% end %>
-              </div>
-            <% else @counselings.blank?%>
-              <P>相談履歴がありません。</P>
-            <% end %>
-            <div class="d-flex">
-              <% if @counselings.present?%>
-                <div class="paginate">
-                  <%= paginate @counselings, param_name: counseling_page('counseling') %>
-                </div>
-              <% end %>
-              <div class="ml-auto">
-                <%= link_to "戻る", :back, class: "btn btn-secondary" %>
-              </div>
-            </div>
+          <div id="counselings-container">
+            <%= render partial: 'projects/counselings/all_counselings', locals: { counselings: @counselings } %>
           </div>
         </div>
       </div>

--- a/app/views/projects/counselings/index.js.erb
+++ b/app/views/projects/counselings/index.js.erb
@@ -1,0 +1,2 @@
+$("#you-addressee-counselings-container").html("<%= escape_javascript(render partial: 'projects/counselings/you_addressee_counselings', locals: { messages: @you_addressee_counselings }) %>");
+$("#counselings-container").html("<%= escape_javascript(render partial: 'projects/counselings/all_counselings', locals: { messages: @counselings }) %>");


### PR DESCRIPTION
### 概要
①相談一覧画面の、ページネーションでのページ遷移不具合を解消。
②rubocopのルール重複問題の解決。

### タスク
- [] なし
- [x] あり _(タスクのリンクがあれば貼る)_
問題表28「ページネーションでのページ遷移不具合」
https://docs.google.com/spreadsheets/d/1qitHpAxSv65lzMyIFgvnDUr-YLbd484bAfxjEI1SDeo/edit#gid=0&range=A29

### 実装内容・手法
①
「全てのタブにページネーションが効いてしまう問題」
「ページネーションで先頭のタブに遷移してしまう問題」
以上２点を、前回の連絡一覧画面と同様の手法で解消。
⇩前回の手法(連絡一覧)
https://docs.google.com/spreadsheets/d/1WOAFNiECOVQavLn_q5JxGR8Y_NPJtSdSFyhTcsqiYww/edit#gid=0

②
.rubocop.ymlファイル内で「Metrics/BlockLength:」が２箇所に分かれて記述されていた為、一つに統合。

### 実装画像などあれば添付する

### gemfileの変更
- [x] なし
- [ ] あり 
