### PR TITLE
相談検索機能追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /myproject
 # ホストのGemfile達をコンテナ内にコピー
 ADD Gemfile /myproject/Gemfile
 ADD Gemfile.lock /myproject/Gemfile.lock
-RUN gem install bundler
+RUN gem install bundler -v 2.4.22
 RUN gem update --system 3.2.3
 RUN bundle install -j4
 #既存railsプロジェクトをコンテナ内にコピー

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -15,7 +15,10 @@ class Projects::CounselingsController < Projects::BaseProjectController
       format.js
     end
     counselings_by_search
-    render :index
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   def show
@@ -191,7 +194,6 @@ class Projects::CounselingsController < Projects::BaseProjectController
       end
       @counselings = @counselings.where(id: @counseling_ids) if @counselings
       @you_addressee_counselings = @you_addressee_counselings.where(id: @counseling_ids) if @you_addressee_counselings
-      @you_send_counselings = @you_send_counselings.when(id: @counseling_ids) if @you_send_counselings
     end
   end
 end

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -14,6 +14,8 @@ class Projects::CounselingsController < Projects::BaseProjectController
       format.html
       format.js
     end
+    counselings_by_search
+    render :index
   end
 
   def show
@@ -124,6 +126,16 @@ class Projects::CounselingsController < Projects::BaseProjectController
     params.require(:counseling).permit(:counseling_detail, :title, { send_to: [] }, :send_to_all)
   end
 
+  def counseling_search_params
+    if params[:search].is_a?(ActionController::Parameters)
+      params.require(:search).permit(:created_at, :keywords)
+    elsif params[:search].is_a?(String)
+      { keywords: params[:search] }
+    else
+      {}
+    end
+  end
+
   def update_counseling_and_confirmers
     if @counseling.update(counseling_params)
       @counseling.counseling_confirmers.destroy_all
@@ -165,6 +177,21 @@ class Projects::CounselingsController < Projects::BaseProjectController
     recipients.each do |recipient|
       recipient = recipient.is_a?(User) ? recipient : User.find(recipient)
       CounselingMailer.notification_edited(recipient, @counseling, @project).deliver_now
+    end
+  end
+
+  def counselings_by_search
+    if params[:search].present? and params[:search] != ""
+      @results = Counseling.search(counseling_search_params)
+      if @results.present?
+        @counseling_ids = @results.pluck(:id).uniq
+      else
+        flash.now[:danger] = '検索結果が見つかりませんでした。'
+        return
+      end
+      @counselings = @counselings.where(id: @counseling_ids) if @counselings
+      @you_addressee_counselings = @you_addressee_counselings.where(id: @counseling_ids) if @you_addressee_counselings
+      @you_send_counselings = @you_send_counselings.when(id: @counseling_ids) if @you_send_counselings
     end
   end
 end

--- a/app/models/counseling.rb
+++ b/app/models/counseling.rb
@@ -36,4 +36,14 @@ class Counseling < ApplicationRecord
       end
     end
   end
+
+  # 検索機能
+  def self.search(search_params)
+    query = all
+    if search_params[:keywords].present?
+      keyword = "%#{search_params[:keywords]}%"
+      query = query.where("title LIKE :keyword OR counseling_detail LIKE :keyword", keyword: keyword)
+    end
+    query
+  end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,7 +1,9 @@
 <nav class="navbar navbar-expand-lg navbar-light header shadow bg-white rounded justify-content-center">
   <%= link_to "Horenso_App", root_path, class: "h1 mb-1" %>
   <% flash.each do |key, value| %>
-    <%= content_tag(:a, value, class: "alert alert-#{bootstrap_alert(key)} mb-0 ml-3") %>
+    <% if key != :search_error %>
+      <%= content_tag(:a, value, class: "alert alert-#{bootstrap_alert(key)} mb-0 ml-3") %>
+    <% end %>
   <% end %>
   <% if user_signed_in? %>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">

--- a/app/views/projects/counselings/_all_counselings.html.erb
+++ b/app/views/projects/counselings/_all_counselings.html.erb
@@ -3,7 +3,7 @@
     <div class="d-flex justify-content-end mb-3">
       <%= form_with scope: :search, url: user_project_counselings_path(current_user, @project), method: :get, remote: true do |form| %>
         <%= form.hidden_field :search_type, :value => "counseling" %>
-        <%= form.label :keywords, "件名検索：", class: "mb-0" %>
+        <%= form.label :keywords, "件名・内容検索：", class: "mb-0" %>
         <%= form.text_field :keywords, placeholder: "キーワードを入力", class: "search-box" %>
         <%= form.submit "検索", class: "btn btn-outline-orange" %>
       <% end %>    

--- a/app/views/projects/counselings/_all_counselings.html.erb
+++ b/app/views/projects/counselings/_all_counselings.html.erb
@@ -1,12 +1,12 @@
 <div class="box-counseling-index">
   <% if @counselings.present? %>
     <div class="d-flex justify-content-end mb-3">
-      <%= form_with url: "#", method: :get, local: true do |form| %>
+      <%= form_with scope: :search, url: user_project_counselings_path(current_user, @project), method: :get, remote: true do |form| %>
         <%= form.hidden_field :search_type, :value => "counseling" %>
-        <%= form.label :search, "件名検索：", class: "mb-0" %>
-        <%= form.text_field :search, placeholder: "キーワードを入力", class: "search-box" %>
+        <%= form.label :keywords, "件名検索：", class: "mb-0" %>
+        <%= form.text_field :keywords, placeholder: "キーワードを入力", class: "search-box" %>
         <%= form.submit "検索", class: "btn btn-outline-orange" %>
-      <% end %>
+      <% end %>    
     </div>
     <div class="table-header">
       <div class="subject-name">

--- a/app/views/projects/counselings/_you_addressee_counselings.html.erb
+++ b/app/views/projects/counselings/_you_addressee_counselings.html.erb
@@ -1,10 +1,10 @@
 <div class="box-you-addressee-index">
   <% if @you_addressee_counselings.present? %>
     <div class="d-flex justify-content-end mb-3">
-      <%= form_with url: "#", method: :get, local: true do |form| %>
+      <%= form_with scope: :search, url: user_project_counselings_path(current_user, @project), method: :get, remote: true do |form| %>
         <%= form.hidden_field :search_type, :value => "you-addressee" %>
-        <%= form.label :search, "件名検索：", class: "mb-0" %>
-        <%= form.text_field :search, placeholder: "キーワードを入力", class: "search-box" %>
+        <%= form.label :keywords, "件名・内容検索：", class: "mb-0" %>
+        <%= form.text_field :keywords, placeholder: "キーワードを入力", class: "search-box" %>
         <%= form.submit "検索", class: "btn btn-outline-orange" %>
       <% end %>
     </div>

--- a/app/views/projects/counselings/index.html.erb
+++ b/app/views/projects/counselings/index.html.erb
@@ -4,6 +4,12 @@
   <%= render partial: 'layouts/sidebar' , locals: { user: @user, project: @project } %>
 <% end %>
 
+<div id="flash-messages">
+  <% flash.each do |key, message| %>
+    <div class="alert alert-<%= key %>"><%= message %></div>
+  <% end %>
+</div>
+
 <div class="card-box">
   <!-- div class="box-project-select">
     <%#= form_with do |form| %>

--- a/app/views/projects/counselings/index.js.erb
+++ b/app/views/projects/counselings/index.js.erb
@@ -1,2 +1,6 @@
+<% if flash.now[:danger] %>
+  $("#flash-messages").html('<div class="alert alert-danger"><%= j flash.now[:danger] %></div>');
+<% end %>
+
 $("#you-addressee-counselings-container").html("<%= escape_javascript(render partial: 'projects/counselings/you_addressee_counselings', locals: { messages: @you_addressee_counselings }) %>");
 $("#counselings-container").html("<%= escape_javascript(render partial: 'projects/counselings/all_counselings', locals: { messages: @counselings }) %>");


### PR DESCRIPTION
### 概要
相談一覧画面にて相談検索機能を追加

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
相談件名、相談内容のワードを入力、完全一致、部分一致で検索可能

### 実装画像などあれば添付する
https://docs.google.com/spreadsheets/d/1zZuioWUIBcg-FuWLLUdkpbVa4anMRSBjtn2VGlLcIsM/edit#gid=1490951114
### gemfileの変更
- [x] なし
- [ ] あり 
