### PR TITLE
手直し機能削除後のエラー修正

### DIFF
--- a/app/views/projects/reports/edit.html.erb
+++ b/app/views/projects/reports/edit.html.erb
@@ -4,14 +4,6 @@
 <div class="box-project-report">
   <p>プロジェクト：<%= @project.name %></p>
   <h1 class="text-center my-3">報告編集</h1>
-  <% if !@report.remanded_reason.nil? && !@report.remanded_reason.blank? %>
-    <div class="btn btn-danger font-weight-bold mb-2" style="pointer-events: none;">
-      コメント
-    </div>
-    <div class="pt-3 pl-1 mb-3 border rounded text-danger">
-      <%= simple_format(@report.remanded_reason) %>
-    </div>
-  <% end %>
   <%= form_with model: @report, url: user_project_report_path(current_user, @project, @report),method: :patch do |f| %>
     <div class="base-background-color px-5 pt-5">
       <div class="report-form">
@@ -41,9 +33,6 @@
         <% end %>
         <%# レンダリング %>
         <div class="text-right mt-3 mr-4 pb-5">
-          <% if @report.remanded == "true" %>
-            <span class="remanded-box font-weight-bold mr-2 rounded">手直しを完了する<%= f.check_box :resubmitted, {checked: ActiveRecord::Type::Boolean.new.cast(@report.resubmitted)}, checked_value = "true", unchecked_value = "false" %></span>
-          <% end %>
           <%= f.submit '変更', class: "btn btn-outline-orange col-2" %>
           <div class="text-center">
             <%= link_to '戻る', :back, class: "btn btn-light btn-outline-secontary col-2 " %>

--- a/app/views/projects/reports/view_reports_log_month.html.erb
+++ b/app/views/projects/reports/view_reports_log_month.html.erb
@@ -68,7 +68,7 @@
           <% (@first_day..@last_day).each do |date| %>
             <% reported_users = @project.reports
                                   .joins(user: :project_users)
-                                  .where(report_day: date, remanded: false, project_users: { member_expulsion: false })
+                                  .where(report_day: date, project_users: { member_expulsion: false })
                                   .where("DATE(reports.created_at) = ?", date)
                                   .select(:user_id).distinct %>
             <tr>
@@ -122,7 +122,7 @@
               <td class="footer">
                 <% reported_days = @project.reports
                                     .joins(user: :project_users)
-                                    .where(report_day: @first_day..@last_day, remanded: false, user_id: user.id, project_users: { member_expulsion: false })
+                                    .where(report_day: @first_day..@last_day, user_id: user.id, project_users: { member_expulsion: false })
                                     .pluck(:report_day).uniq %>
                 <% valid_reported_days = reported_days.select { |day| user.reports.find_by(report_day: day).created_at.to_date == day } %>
                 <% total_days = @report_days.count %>
@@ -144,7 +144,7 @@
               <% (@first_day..@last_day).each do |date| %>
                 <% reported_users = @project.reports
                                       .joins(user: :project_users)
-                                      .where(report_day: date, remanded: false, project_users: { member_expulsion: false })
+                                      .where(report_day: date, project_users: { member_expulsion: false })
                                       .where("DATE(reports.created_at) = ?", date)
                                       .select(:user_id).distinct %>
                 <% total_reported_users += reported_users.count %>


### PR DESCRIPTION
### 概要
手直し機能削除時の不備によるエラーを修正。

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
報告集計（一か月の集計）画面、報告編集画面遷移時のエラー、
手直し機能のカラム「remanded、remanded_reason、resubmitted」が残っているコードを削除・修正。

### 実装画像などあれば添付する

### gemfileの変更
- [x] なし
- [ ] あり 
