### PR TITLE
返信機能のRspec対応(モデルspec追加)

### DIFF
--- a/app/models/counseling_reply.rb
+++ b/app/models/counseling_reply.rb
@@ -2,5 +2,5 @@ class CounselingReply < ApplicationRecord
   belongs_to :counseling
   has_many_attached :images, dependent: :destroy
 
-  validates :reply_content, presence: true
+  validates :reply_content, presence: true, length: { maximum: 500 }
 end

--- a/app/models/message_reply.rb
+++ b/app/models/message_reply.rb
@@ -2,5 +2,5 @@ class MessageReply < ApplicationRecord
   belongs_to :message
   has_many_attached :images, dependent: :destroy
 
-  validates :reply_content, presence: true
+  validates :reply_content, presence: true, length: { maximum: 500 }
 end

--- a/app/models/report_reply.rb
+++ b/app/models/report_reply.rb
@@ -2,5 +2,5 @@ class ReportReply < ApplicationRecord
   belongs_to :report
   has_many_attached :images, dependent: :destroy
 
-  validates :reply_content, presence: true
+  validates :reply_content, presence: true, length: { maximum: 500 }
 end

--- a/spec/factories/counseling_replys.rb
+++ b/spec/factories/counseling_replys.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :counseling_reply do
+    association :counseling
+    reply_content { '返信内容' }
+  end
+end

--- a/spec/factories/counselings.rb
+++ b/spec/factories/counselings.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :counseling do
+    association :project
+    id { 1 }
+    project_id { 1 }
+    sender_id { 1 }
+    sender_name { '相談者' }
+    title { 'a' * 25 }
+    counseling_detail { '相談内容' }
+    created_at { '2023-01-01' }
+    updated_at { '2023-01-01' }
+  end
+end

--- a/spec/factories/message_replys.rb
+++ b/spec/factories/message_replys.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :message_reply do
+    association :message
+    reply_content { '返信内容' }
+  end
+end

--- a/spec/factories/report_replys.rb
+++ b/spec/factories/report_replys.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :report_reply do
+    association :report
+    reply_content { '返信内容' }
+  end
+end

--- a/spec/models/counseling_reply_spec.rb
+++ b/spec/models/counseling_reply_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe CounselingReply, type: :model do
+  describe "counseling_replyの登録" do
+    context "reply_contentカラム" do
+      it "返信本文があれば投稿できる" do
+        expect(build(:counseling_reply, reply_content: 'a')).to be_valid
+      end
+
+      it "返信本文がなければ投稿できない" do
+        expect(build(:counseling_reply, reply_content: '')).to be_invalid
+      end
+
+      it "返信本文が500文字までは投稿できる" do
+        expect(build(:counseling_reply, reply_content: "a" * 500)).to be_valid
+      end
+
+      it "返信本文が500文字を超えると投稿できない" do
+        expect(build(:counseling_reply, reply_content: "a" * 501)).to be_invalid
+      end
+    end
+  end
+end

--- a/spec/models/message_reply_spec.rb
+++ b/spec/models/message_reply_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe MessageReply, type: :model do
+  describe "message_replyの登録" do
+    context "reply_contentカラム" do
+      it "返信本文があれば投稿できる" do
+        expect(build(:message_reply, reply_content: 'a')).to be_valid
+      end
+
+      it "返信本文がなければ投稿できない" do
+        expect(build(:message_reply, reply_content: '')).to be_invalid
+      end
+
+      it "返信本文が500文字までは投稿できる" do
+        expect(build(:message_reply, reply_content: "a" * 500)).to be_valid
+      end
+
+      it "返信本文が500文字を超えると投稿できない" do
+        expect(build(:message_reply, reply_content: "a" * 501)).to be_invalid
+      end
+    end
+  end
+end

--- a/spec/models/report_reply_spec.rb
+++ b/spec/models/report_reply_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ReportReply, type: :model do
+  describe "report_replyの登録" do
+    context "reply_contentカラム" do
+      it "返信本文があれば投稿できる" do
+        expect(build(:report_reply, reply_content: 'a')).to be_valid
+      end
+
+      it "返信本文がなければ投稿できない" do
+        expect(build(:report_reply, reply_content: '')).to be_invalid
+      end
+
+      it "返信本文が500文字までは投稿できる" do
+        expect(build(:report_reply, reply_content: "a" * 500)).to be_valid
+      end
+
+      it "返信本文が500文字を超えると投稿できない" do
+        expect(build(:report_reply, reply_content: "a" * 501)).to be_invalid
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 概要
【テストフェーズ】返信機能のテスト
① Rspecによるテストコード実装
② 打鍵テストにて発見した不具合の修正

### タスク
- [x] なし
- [ ] あり 

### 実装内容・手法
① Rspec対応
⇨ 報告 / 連絡 / 相談の各返信機能のモデルspec追加

② 不具合対応
⇨ ReportReply, MessageReply, CounselingReplyモデルのバリデーション変更
     ⇨ 報告 / 連絡 / 相談の各返信機能における返信本文の文字数制限(500文字まで)を設定

### gemfileの変更
- [x] なし
- [ ] あり 

### RSpec実行コマンド
【テストケース全実行】
docker-compose run --rm app bundle exec rspec
【テストケース個別実行】※ 今回追加したテストケースの個別実行
docker-compose run --rm app bundle exec rspec spec/models/report_reply_spec.rb  
docker-compose run --rm app bundle exec rspec spec/models/message_reply_spec.rb  
docker-compose run --rm app bundle exec rspec spec/models/counseling_reply_spec.rb  
