### PR TITLE
Feat/report remind fixing and resetting

### DIFF
--- a/app/assets/javascripts/projects/report_reminder.js
+++ b/app/assets/javascripts/projects/report_reminder.js
@@ -9,12 +9,56 @@ $(document).on('turbolinks:load', function(){
       var reminderSettingContainer = $(this).closest('.project-member-action').find('.reminder-setting');
       var selectElement = reminderSettingContainer.find('.form-control');
 
+      // 切替スイッチがオンの場合、リマインド設定を表示
       if (this.checked) {
         reminderSettingContainer.show();
         selectElement.prop('disabled', false);
+
+        // 選択日数の選択を解除（デフォルト化）
+        var optionsCount = parseInt($(this).closest('.project-member-action').data('report-frequency'));
+        selectElement.html('');
+        for (var i = 0; i < optionsCount; i++) {
+          var option = $('<option>').val(i).text(i === 0 ? '当日' : i + '日前');
+          if (i === 0) {
+            option.attr('selected', true);
+          }
+          selectElement.append(option);
+        }
+
+      // 切替スイッチがオフの場合の場合、リマインド設定を非表示＆解除
       } else {
         reminderSettingContainer.hide();
         selectElement.prop('disabled', true);
+  
+        var userId = $(this).data('user-id');
+        var projectId = $(this).data('project-id');
+        var memberId = $(this).data('member-id');
+
+        // 選択時刻の選択を解除
+        var timeInput = $(this).closest('.project-member-action').find('.form-control[type="time"]');
+        timeInput.val('');  // デフォルトの選択をクリア
+
+        // 設定をリセットするAjaxリクエストを送信
+        $.ajax({
+          url: '/projects/members/reset_reminder',
+          type: 'POST',
+          data: {
+            user_id: userId,
+            project_id: projectId,
+            member_id: memberId
+          },
+          headers: {
+            'X-CSRF-Token': csrfToken
+          },
+          success: function(data) {
+            // 成功時の処理
+            alert("報告リマインドの設定をリセットしました。\n\n【注意】\n既に完了済の設定は 1ヶ月間 解除されません。");
+          },
+          error: function() {
+            // エラー時の処理
+            alert("エラーが発生したため、報告リマインド設定をリセット出来ませんでした。");
+          }
+        });
       }
     });
   });
@@ -104,7 +148,7 @@ $(document).on('turbolinks:load', function(){
       var timeInput = $(this).closest('.project-member-action').find('.form-control[type="time"]');
       var reportTime = timeInput.val();
   
-      // Ajaxリクエストを送信
+      // 報告リマインドを設定するAjaxリクエストを送信
       $.ajax({
         url: '/projects/members/send_reminder',
         type: 'POST',
@@ -123,11 +167,11 @@ $(document).on('turbolinks:load', function(){
         },
         success: function(data) {
           // 成功時の処理
-          alert("報告リマインドの設定が完了しました。設定は 1ヶ月間 有効です。");
+          alert("報告リマインドの設定が完了しました。\n\n設定は 1ヶ月間 有効です。");
         },
         error: function() {
           // エラー時の処理
-          alert("報告リマインドの設定でエラーが発生しました。設定には日時の選択が両方とも必要です。");
+          alert("報告リマインドの設定でエラーが発生しました。\n\n設定には日時の選択が両方とも必要です。");
         }
       });
     });

--- a/app/assets/javascripts/projects/report_reminder.js
+++ b/app/assets/javascripts/projects/report_reminder.js
@@ -23,7 +23,10 @@ $(document).on('turbolinks:load', function(){
   $(function($) {
     // メンバー一覧画面からデータを取得
     var reportFrequencies = $('.project-member-action').map(function() {
-      return parseInt($(this).data('report-frequency'));
+      return {
+        reportFrequency: parseInt($(this).data('report-frequency')),
+        selectedDays: parseInt($(this).find('.form-control').data('selected-days'))
+      };
     }).get();
 
     // 日にち選択肢を制御する関数
@@ -32,7 +35,9 @@ $(document).on('turbolinks:load', function(){
       $('.project-member-action').each(function(index) {
         var reminderSettingContainer = $(this).find('.reminder-setting');
         var selectElement = reminderSettingContainer.find('.form-control');
-        var reportFrequency = reportFrequencies[index];
+
+        var reportFrequency = reportFrequencies[index].reportFrequency;
+        var selectedDays = reportFrequencies[index].selectedDays;
 
         // 日にち選択肢を一旦クリア
         selectElement.html('');
@@ -40,13 +45,27 @@ $(document).on('turbolinks:load', function(){
         // 報告頻度に応じて日にち選択肢の最大値を設定
         var optionsCount = reportFrequency;
 
-        // 日にち選択肢を再生成
-        for (var i = 0; i < optionsCount; i++) {
-          var option = $('<option>').val(i).text(i === 0 ? '当日' : i + '日前');
-          if (i === 0) {
-            option.attr('selected', true);
+        // ユーザーのreminder_daysおよびreport_timeの値を取得
+        var reminderDays = parseInt($(this).data('selected-days'));
+
+        // reminder_enabledがtrueの場合、設定済の選択日数を初期表示するよう日にち選択肢を再生成
+        if (reminderDays !== null) {
+          for (var i = 0; i < optionsCount; i++) {
+            var option = $('<option>').val(i).text(i === 0 ? '当日' : i + '日前');
+            if (i === selectedDays) { // ここを変更
+              option.attr('selected', true);
+            }
+            selectElement.append(option);
           }
-          selectElement.append(option);
+        } else {
+          // reminder_enabledがfalseの場合、デフォルトの日にち選択肢を再生成
+          for (var i = 0; i < optionsCount; i++) {
+            var option = $('<option>').val(i).text(i === 0 ? '当日' : i + '日前');
+            if (i === 0) {
+              option.attr('selected', true);
+            }
+            selectElement.append(option);
+          }
         }
 
         // 時刻選択用の<input>要素を取得

--- a/app/assets/javascripts/projects/report_reminder.js
+++ b/app/assets/javascripts/projects/report_reminder.js
@@ -45,20 +45,23 @@ $(document).on('turbolinks:load', function(){
         // 報告頻度に応じて日にち選択肢の最大値を設定
         var optionsCount = reportFrequency;
 
-        // ユーザーのreminder_daysおよびreport_timeの値を取得
+        // 選択日数の値を取得
         var reminderDays = parseInt($(this).data('selected-days'));
 
-        // reminder_enabledがtrueの場合、設定済の選択日数を初期表示するよう日にち選択肢を再生成
+        // 報告リマインドが設定済の場合、設定済の選択日数＆選択時刻を初期表示するよう生成
         if (reminderDays !== null) {
           for (var i = 0; i < optionsCount; i++) {
             var option = $('<option>').val(i).text(i === 0 ? '当日' : i + '日前');
-            if (i === selectedDays) { // ここを変更
+            if (i === selectedDays) {
               option.attr('selected', true);
             }
             selectElement.append(option);
           }
+          // 時刻選択用の<input>要素を取得
+          var timeInput = reminderSettingContainer.find('input[type="time"]');
+
+        // 報告リマインドが未設定の場合、デフォルトの日にち選択肢＆時刻選択肢を生成
         } else {
-          // reminder_enabledがfalseの場合、デフォルトの日にち選択肢を再生成
           for (var i = 0; i < optionsCount; i++) {
             var option = $('<option>').val(i).text(i === 0 ? '当日' : i + '日前');
             if (i === 0) {
@@ -66,11 +69,10 @@ $(document).on('turbolinks:load', function(){
             }
             selectElement.append(option);
           }
+          // 時刻選択用の<input>要素を取得
+          var timeInput = reminderSettingContainer.find('input[type="time"]');
+          timeInput.val('');  // デフォルトの選択をクリア
         }
-
-        // 時刻選択用の<input>要素を取得
-        var timeInput = reminderSettingContainer.find('input[type="time"]');
-        timeInput.val('');  // デフォルトの選択をクリア
 
         // 時刻選択肢を再生成
         var timeOption = $('<option>').val('').text('');  // デフォルトの選択

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -158,13 +158,6 @@ class Projects::MembersController < Projects::BaseProjectController
         report_time: report_time
       )
 
-      # ログに出力してデバッグ
-      logger.debug "Reminder Settings for project_user_id=#{project_user.id}: "
-      logger.debug "report_frequency=#{project.report_frequency}, "
-      logger.debug "reminder_enabled=#{project_user.reminder_enabled}, "
-      logger.debug "reminder_days=#{project_user.reminder_days}, "
-      logger.debug "report_time=#{project_user.report_time}"
-
       # 設定した project_user を返す
       project_user
     end
@@ -185,14 +178,6 @@ class Projects::MembersController < Projects::BaseProjectController
       report_time: nil,
       report_reminder_time: nil
     )
-
-    # ログに出力してデバッグ
-    logger.debug "Reminder Settings Disabled for project_user_id=#{project_user.id}"
-    logger.debug "report_frequency=#{project.report_frequency}, "
-    logger.debug "reminder_enabled=#{project_user.reminder_enabled}, "
-    logger.debug "reminder_days=#{project_user.reminder_days}, "
-    logger.debug "report_time=#{project_user.report_time}"
-    logger.debug "report_reminder_time=#{project_user.report_reminder_time}"
 
     # 設定した project_user を返す
     project_user

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -122,6 +122,7 @@ class Projects::MembersController < Projects::BaseProjectController
     nil
   end
 
+  # リマインダー用の各処理を実行するメソッド（報告リマインド用）
   def process_report_reminder(project, member_id, report_frequency, reminder_days, report_time)
     Time.use_zone('Asia/Tokyo') do
       project_user = find_project_user(project, member_id)

--- a/app/models/project_user.rb
+++ b/app/models/project_user.rb
@@ -90,4 +90,16 @@ class ProjectUser < ApplicationRecord
       Rails.logger.warn "Invalid report_reminder_datetime: #{reminder_datetime}. #{error_message}"
     end
   end
+
+  # 報告リマインドメール送信ジョブをキューから削除するメソッド
+  def dequeue_report_reminder # （考察：実装時には queue_report_reminder と同じ引数を要する可能性アリ）
+    # キューから削除する処理を追加
+
+    # （考察：Sidekiq＋Redisを導入後、例えば以下のような記述になる可能性アリ）
+    # Sidekiq::ScheduledSet.new.each do |job|
+    #   job.delete if job.args.include?(self.id)
+    # end
+
+    # 【注意】別ファイルにて、Sidekiq＋RedisをDocker上で導入する実装が少なくとも必要。
+  end
 end

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -59,7 +59,8 @@
                     </select>
                     <label for="reminderDays<%= member.id %>">の</label>
                     <!--報告リマインドの時刻選択ドロップダウン（プロジェクトメンバー用／設定済の場合）-->
-                    <input type="time" class="form-control" id="timeInput<%= member.id %>" name="report_time">
+                    <input type="time" class="form-control" id="timeInput<%= member.id %>" name="report_time" value="<%= @project_user.reminder_enabled ? @project_user.report_time.strftime('%H:%M') : '' %>">
+                    <% logger.debug("Report Time Value: #{@project_user.reminder_enabled ? @project_user.report_time.strftime('%H:%M') : ''}") %>
                     <label for="timeInput<%= member.id %>">に</label>
                     <!--選択した報告リマインド日時の設定ボタン（プロジェクトメンバー用／設定済の場合）-->
                     <button type="button" class="btn btn-success btn-sm set-reminder" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>">設定</button>
@@ -86,22 +87,47 @@
             <% elsif project_leader? %>
               <div class="project-member-action member-text" data-report-frequency="<%= @report_frequency %>">
                 <% if @user.id == member.id %>
-                  <div class="custom-control custom-switch">
-                    報告リマインドを設定（メール）
-                    <!--報告リマインド用のオンオフ切替スイッチ（プロジェクトリーダー用）-->
-                    <input type="checkbox" class="custom-control-input" id="customSwitch<%= member.id %>" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>">
-                    <label class="custom-control-label" for="customSwitch<%= member.id %>"></label>
-                  </div>
-                  <div class="form-group reminder-setting" style="display: none;">
-                    <!--報告リマインドの日にち選択ドロップダウン（プロジェクトリーダー用）-->
-                    <select class="form-control" id="reminderDays<%= member.id %>" disabled></select>
-                    <label for="reminderDays<%= member.id %>">の</label>
-                    <!--報告リマインドの時刻選択ドロップダウン（プロジェクトリーダー用）-->
-                    <input type="time" class="form-control" id="timeInput<%= member.id %>" name="report_time" disabled>
-                    <label for="timeInput<%= member.id %>">に</label>
-                    <!--選択した報告リマインド日時の設定ボタン（プロジェクトリーダー用）-->
-                    <button type="button" class="btn btn-success btn-sm set-reminder" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>">設定</button>
-                  </div>
+                  <% if @project_user.reminder_enabled == true %>
+                    <div class="custom-control custom-switch">
+                      報告リマインドを設定（メール）
+                      <!-- 報告リマインド用のオンオフ切替スイッチ（プロジェクトリーダー用／設定済の場合） -->
+                      <input type="checkbox" class="custom-control-input" id="customSwitch<%= member.id %>" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>" checked>
+                      <label class="custom-control-label" for="customSwitch<%= member.id %>"></label>
+                    </div>
+                    <div class="form-group reminder-setting">
+                      <!--報告リマインドの日にち選択ドロップダウン（プロジェクトリーダー用／設定済の場合）-->
+                      <select class="form-control" id="reminderDays<%= member.id %>" data-selected-days="<%= @project_user.reminder_days %>">
+                      <% logger.debug("Report Frequency: #{@report_frequency}") %>
+                        <% (0..(@report_frequency-1)).each do |i| %>
+                          <% selected = i == @project_user.reminder_days ? 'selected' : '' %>
+                          <option value="<%= i %>" <%= selected %>><%= i === 0 ? '当日' : i.to_s + '日前' %></option>
+                        <% end %>
+                      </select>
+                      <label for="reminderDays<%= member.id %>">の</label>
+                      <!--報告リマインドの時刻選択ドロップダウン（プロジェクトリーダー用／設定済の場合）-->
+                      <input type="time" class="form-control" id="timeInput<%= member.id %>" name="report_time" value="<%= @project_user.reminder_enabled ? @project_user.report_time.strftime('%H:%M') : '' %>">
+                      <label for="timeInput<%= member.id %>">に</label>
+                      <!--選択した報告リマインド日時の設定ボタン（プロジェクトリーダー用／設定済の場合）-->
+                      <button type="button" class="btn btn-success btn-sm set-reminder" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>">設定</button>
+                    </div>
+                  <% else %>
+                    <div class="custom-control custom-switch">
+                      報告リマインドを設定（メール）
+                      <!-- 報告リマインド用のオンオフ切替スイッチ（プロジェクトリーダー用／未設定の場合） -->
+                      <input type="checkbox" class="custom-control-input" id="customSwitch<%= member.id %>" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>">
+                      <label class="custom-control-label" for="customSwitch<%= member.id %>"></label>
+                    </div>
+                      <div class="form-group reminder-setting" style="display: none;">
+                      <!--報告リマインドの日にち選択ドロップダウン（プロジェクトリーダー用／未設定の場合）-->
+                      <select class="form-control" id="reminderDays<%= member.id %>" disabled></select>
+                      <label for="reminderDays<%= member.id %>">の</label>
+                      <!--報告リマインドの時刻選択ドロップダウン（プロジェクトリーダー用／未設定の場合）-->
+                      <input type="time" class="form-control" id="timeInput<%= member.id %>" name="report_time" disabled>
+                      <label for="timeInput<%= member.id %>">に</label>
+                      <!--選択した報告リマインド日時の設定ボタン（プロジェクトリーダー用／未設定の場合）-->
+                      <button type="button" class="btn btn-success btn-sm set-reminder" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>">設定</button>
+                    </div>
+                  <% end %>
                 <% end %>
                 <% unless @project.leader_id == member.id %>
                   <% if member.member_expulsion %>

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -49,14 +49,7 @@
                   </div>
                   <div class="form-group reminder-setting">
                     <!--報告リマインドの日にち選択ドロップダウン（プロジェクトメンバー用／設定済の場合）-->
-                    <select class="form-control" id="reminderDays<%= member.id %>" data-selected-days="<%= @project_user.reminder_days %>">
-                    <% logger.debug("Report Frequency: #{@report_frequency}") %>
-                      <% (0..(@report_frequency-1)).each do |i| %>
-                        <% logger.debug("Reminder Days: #{i}, Project User Reminder Days: #{@project_user.reminder_days}") %>
-                        <% selected = i == @project_user.reminder_days ? 'selected' : '' %>
-                        <option value="<%= i %>" <%= selected %>><%= i === 0 ? '当日' : i.to_s + '日前' %></option>
-                      <% end %>
-                    </select>
+                    <select class="form-control" id="reminderDays<%= member.id %>" data-selected-days="<%= @project_user.reminder_days %>"></select>
                     <label for="reminderDays<%= member.id %>">の</label>
                     <!--報告リマインドの時刻選択ドロップダウン（プロジェクトメンバー用／設定済の場合）-->
                     <input type="time" class="form-control" id="timeInput<%= member.id %>" name="report_time" value="<%= @project_user.reminder_enabled ? @project_user.report_time.strftime('%H:%M') : '' %>">
@@ -96,13 +89,7 @@
                     </div>
                     <div class="form-group reminder-setting">
                       <!--報告リマインドの日にち選択ドロップダウン（プロジェクトリーダー用／設定済の場合）-->
-                      <select class="form-control" id="reminderDays<%= member.id %>" data-selected-days="<%= @project_user.reminder_days %>">
-                      <% logger.debug("Report Frequency: #{@report_frequency}") %>
-                        <% (0..(@report_frequency-1)).each do |i| %>
-                          <% selected = i == @project_user.reminder_days ? 'selected' : '' %>
-                          <option value="<%= i %>" <%= selected %>><%= i === 0 ? '当日' : i.to_s + '日前' %></option>
-                        <% end %>
-                      </select>
+                      <select class="form-control" id="reminderDays<%= member.id %>" data-selected-days="<%= @project_user.reminder_days %>"></select>
                       <label for="reminderDays<%= member.id %>">の</label>
                       <!--報告リマインドの時刻選択ドロップダウン（プロジェクトリーダー用／設定済の場合）-->
                       <input type="time" class="form-control" id="timeInput<%= member.id %>" name="report_time" value="<%= @project_user.reminder_enabled ? @project_user.report_time.strftime('%H:%M') : '' %>">

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -40,22 +40,48 @@
             </div>
             <% if @user.id == member.id %>
               <div class="project-member-action member-text" data-report-frequency="<%= @report_frequency %>">
-                <div class="custom-control custom-switch">
-                  報告リマインドを設定（メール）
-                  <!--報告リマインド用のオンオフ切替スイッチ（プロジェクトメンバー用）-->
-                  <input type="checkbox" class="custom-control-input" id="customSwitch<%= member.id %>" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>">
-                  <label class="custom-control-label" for="customSwitch<%= member.id %>"></label>
-                </div>
-                <div class="form-group reminder-setting" style="display: none;">
-                  <!--報告リマインドの日にち選択ドロップダウン（プロジェクトメンバー用）-->
-                  <select class="form-control" id="reminderDays<%= member.id %>" disabled></select>
-                  <label for="reminderDays<%= member.id %>">の</label>
-                  <!--報告リマインドの時刻選択ドロップダウン（プロジェクトメンバー用）-->
-                  <input type="time" class="form-control" id="timeInput<%= member.id %>" name="report_time" disabled>
-                  <label for="timeInput<%= member.id %>">に</label>
-                  <!--選択した報告リマインド日時の設定ボタン（プロジェクトメンバー用）-->
-                  <button type="button" class="btn btn-success btn-sm set-reminder" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>">設定</button>
-                </div>
+                <% if @project_user.reminder_enabled == true %>
+                  <div class="custom-control custom-switch">
+                    報告リマインドを設定（メール）
+                    <!-- 報告リマインド用のオンオフ切替スイッチ（プロジェクトメンバー用／設定済の場合） -->
+                    <input type="checkbox" class="custom-control-input" id="customSwitch<%= member.id %>" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>" checked>
+                    <label class="custom-control-label" for="customSwitch<%= member.id %>"></label>
+                  </div>
+                  <div class="form-group reminder-setting">
+                    <!--報告リマインドの日にち選択ドロップダウン（プロジェクトメンバー用／設定済の場合）-->
+                    <select class="form-control" id="reminderDays<%= member.id %>" data-selected-days="<%= @project_user.reminder_days %>">
+                    <% logger.debug("Report Frequency: #{@report_frequency}") %>
+                      <% (0..(@report_frequency-1)).each do |i| %>
+                        <% logger.debug("Reminder Days: #{i}, Project User Reminder Days: #{@project_user.reminder_days}") %>
+                        <% selected = i == @project_user.reminder_days ? 'selected' : '' %>
+                        <option value="<%= i %>" <%= selected %>><%= i === 0 ? '当日' : i.to_s + '日前' %></option>
+                      <% end %>
+                    </select>
+                    <label for="reminderDays<%= member.id %>">の</label>
+                    <!--報告リマインドの時刻選択ドロップダウン（プロジェクトメンバー用／設定済の場合）-->
+                    <input type="time" class="form-control" id="timeInput<%= member.id %>" name="report_time">
+                    <label for="timeInput<%= member.id %>">に</label>
+                    <!--選択した報告リマインド日時の設定ボタン（プロジェクトメンバー用／設定済の場合）-->
+                    <button type="button" class="btn btn-success btn-sm set-reminder" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>">設定</button>
+                  </div>
+                <% else %>
+                  <div class="custom-control custom-switch">
+                    報告リマインドを設定（メール）
+                    <!-- 報告リマインド用のオンオフ切替スイッチ（プロジェクトメンバー用／未設定の場合） -->
+                    <input type="checkbox" class="custom-control-input" id="customSwitch<%= member.id %>" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>">
+                    <label class="custom-control-label" for="customSwitch<%= member.id %>"></label>
+                  </div>
+                    <div class="form-group reminder-setting" style="display: none;">
+                    <!--報告リマインドの日にち選択ドロップダウン（プロジェクトメンバー用／未設定の場合）-->
+                    <select class="form-control" id="reminderDays<%= member.id %>" disabled></select>
+                    <label for="reminderDays<%= member.id %>">の</label>
+                    <!--報告リマインドの時刻選択ドロップダウン（プロジェクトメンバー用／未設定の場合）-->
+                    <input type="time" class="form-control" id="timeInput<%= member.id %>" name="report_time" disabled>
+                    <label for="timeInput<%= member.id %>">に</label>
+                    <!--選択した報告リマインド日時の設定ボタン（プロジェクトメンバー用／未設定の場合）-->
+                    <button type="button" class="btn btn-success btn-sm set-reminder" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>">設定</button>
+                  </div>
+                <% end %>
               </div>
             <% elsif project_leader? %>
               <div class="project-member-action member-text" data-report-frequency="<%= @report_frequency %>">

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -53,7 +53,6 @@
                     <label for="reminderDays<%= member.id %>">の</label>
                     <!--報告リマインドの時刻選択ドロップダウン（プロジェクトメンバー用／設定済の場合）-->
                     <input type="time" class="form-control" id="timeInput<%= member.id %>" name="report_time" value="<%= @project_user.reminder_enabled ? @project_user.report_time.strftime('%H:%M') : '' %>">
-                    <% logger.debug("Report Time Value: #{@project_user.reminder_enabled ? @project_user.report_time.strftime('%H:%M') : ''}") %>
                     <label for="timeInput<%= member.id %>">に</label>
                     <!--選択した報告リマインド日時の設定ボタン（プロジェクトメンバー用／設定済の場合）-->
                     <button type="button" class="btn btn-success btn-sm set-reminder" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>">設定</button>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,7 +100,8 @@ Rails.application.routes.draw do
   end
 
   # 報告リマインド用アクションを追加
-  post '/projects/members/send_reminder', to: 'projects/members#send_reminder'
+  post '/projects/members/send_reminder', to: 'projects/members#send_reminder' # 報告リマインドを設定
+  post '/projects/members/reset_reminder', to: 'projects/members#reset_reminder' # 報告リマインド設定をリセット
 
   #letter_openerを追加
   if Rails.env.development?

--- a/db/migrate/20240202134449_add_columns_to_project_users.rb
+++ b/db/migrate/20240202134449_add_columns_to_project_users.rb
@@ -1,0 +1,7 @@
+class AddColumnsToProjectUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :project_users, :reminder_enabled, :boolean, default: false
+    add_column :project_users, :reminder_days, :integer
+    add_column :project_users, :report_time, :time
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_17_142430) do
+ActiveRecord::Schema.define(version: 2024_02_02_134449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,6 +169,9 @@ ActiveRecord::Schema.define(version: 2023_12_17_142430) do
     t.datetime "updated_at", null: false
     t.boolean "member_expulsion", default: false, null: false
     t.datetime "report_reminder_time"
+    t.boolean "reminder_enabled", default: false
+    t.integer "reminder_days"
+    t.time "report_time"
     t.index ["project_id"], name: "index_project_users_on_project_id"
     t.index ["user_id"], name: "index_project_users_on_user_id"
   end


### PR DESCRIPTION
### 概要
報告リマインド日時設定の表示固定化＆スイッチoff時の表示リセット化の実装

### タスク
- [ ] なし
- [x] あり _(タスクのリンクがあれば貼る)_

・機能分類No.239：再遷移時のリマインド設定表示の固定＆スイッチoff時の表示リセット

### 実装内容・手法
＜既存ファイルへの追記＆編集＞
①app\views\projects\members\index.html.erb（メンバー一覧画面）にて、表示固定化＆表示リセット化の為の追記＆編集。
②app\assets\javascripts\projects\report_reminder.jsにて、表示固定化＆表示リセット化の為の追記＆編集。
③app\controllers\projects\members_controller.rbに、表示固定化用の既存メソッド編集＆表示リセット化用の新アクション＆新メソッド追加。
④app\models\project_user.rbにて、設定リセット化用の新メソッドを仮設置（中身は未実装）。
⑤config\routes.rbにて、表示＆設定リセット化用の新アクションを生成（設定リセットは未実装）。

＜新規ファイルの生成＞
①db\migrate\20240202134449_add_columns_to_project_users.rbにて、表示固定化＆表示リセット化用の新カラムをproject_usersテーブルに追加するマイグレーションファイルを生成。


※補足※
・設定した報告リマインド日時は「1ヶ月先まで」反映。
・設定した報告リマインド日時が過去となる場合、次の次回報告日を基準に反映。
・スイッチをoffにして表示をリセットしても、一度完了した設定は「1ヶ月先まで」有効のまま残る。
　（設定そのもののリセット化は未実装）
・報告リマインドメール内リンクでの直接遷移はログイン中のみ可能。ログアウト時はログイン画面へ遷移。
　（フレンドリーフォワーディング機能は未実装）
・上記③コントローラー、④モデル、報告リマインド用ジョブのそれぞれにタイムゾーン変換を直接記述する事で、
　日本時刻JSTと世界標準イギリス時刻UTCとの9時間差の設定ズレを解消。


### 実装画像などあれば添付する
https://docs.google.com/spreadsheets/d/1zZuioWUIBcg-FuWLLUdkpbVa4anMRSBjtn2VGlLcIsM/edit#gid=42518941
（画面設計内に記載されている＜第3段階＞部分が、今回の機能実装です。）

### gemfileの変更
- [x] なし
- [ ] あり 
