### PR TITLE
報告・連絡・相談の新規作成時における画像添付機能追加

### DIFF
--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -50,6 +50,9 @@ class Projects::CounselingsController < Projects::BaseProjectController
   # rubocop:disable Metrics/AbcSize
   def create
     set_project_and_members
+    unless params[:counseling][:images].nil?
+      set_enable_images(params[:counseling][:image_enable], params[:counseling][:images])
+    end
     @counseling = @project.counselings.new(counseling_params)
     @counseling.sender_id = current_user.id
     @counseling.sender_name = current_user.name
@@ -126,7 +129,7 @@ class Projects::CounselingsController < Projects::BaseProjectController
   private
 
   def counseling_params
-    params.require(:counseling).permit(:counseling_detail, :title, { send_to: [] }, :send_to_all)
+    params.require(:counseling).permit(:counseling_detail, :title, { send_to: [] }, :send_to_all, images: [])
   end
 
   def counseling_search_params

--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -42,6 +42,9 @@ class Projects::MessagesController < Projects::BaseProjectController
 
   def create
     set_project_and_members
+    unless params[:message][:images].nil?
+      set_enable_images(params[:message][:image_enable], params[:message][:images])
+    end
     @message = @project.messages.new(message_params)
     @message.sender_id = current_user.id
     @message.sender_name = current_user.name
@@ -126,7 +129,7 @@ class Projects::MessagesController < Projects::BaseProjectController
   end
 
   def message_params
-    params.require(:message).permit(:message_detail, :title, :importance, { send_to: [] }, :send_to_all)
+    params.require(:message).permit(:message_detail, :title, :importance, { send_to: [] }, :send_to_all, images: [])
   end
 
   def my_message

--- a/app/controllers/projects/reports_controller.rb
+++ b/app/controllers/projects/reports_controller.rb
@@ -74,6 +74,9 @@ class Projects::ReportsController < Projects::BaseProjectController
   def create
     @user = User.find(params[:user_id])
     @project = Project.find(params[:project_id])
+    unless params[:report][:images].nil?
+      set_enable_images(params[:report][:image_enable], params[:report][:images])
+    end
     @report = @project.reports.new(create_reports_params)
     @report.sender_id = @user.id
     @report.sender_name = @user.name
@@ -96,7 +99,6 @@ class Projects::ReportsController < Projects::BaseProjectController
     @user = current_user
     @project = Project.get_report_questions_includes(params[:project_id])
     @report = Report.includes(:answers).find(params[:id])
-
     ActiveRecord::Base.transaction do
       # rubocop:disable Lint/UnusedBlockArgument
       create_reports_params[:answers_attributes].each do |key, answer|
@@ -201,7 +203,8 @@ class Projects::ReportsController < Projects::BaseProjectController
     params.require(:report).permit(:id, :user_id, :project_id, :title, :report_day,
       answers_attributes: [
         :id, :question_type, :question_id, :value, array_value: []
-      ])
+      ],
+      images: [])
   end
 
   def report_search_params

--- a/app/models/counseling.rb
+++ b/app/models/counseling.rb
@@ -2,6 +2,7 @@ class Counseling < ApplicationRecord
   belongs_to :project
   has_many :counseling_confirmers, dependent: :destroy
   has_many :counseling_replies, dependent: :destroy
+  has_many_attached :images, dependent: :destroy
 
   attr_accessor :send_to
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,6 +2,7 @@ class Message < ApplicationRecord
   belongs_to :project
   has_many :message_confirmers, dependent: :destroy
   has_many :message_replies, dependent: :destroy
+  has_many_attached :images, dependent: :destroy
 
   attr_accessor :send_to
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,6 +4,7 @@ class Report < ApplicationRecord
   has_many :answers, dependent: :destroy
   has_many :report_confirmers, dependent: :destroy
   has_many :report_replies, dependent: :destroy
+  has_many_attached :images, dependent: :destroy
 
   attr_accessor :leader_id
 

--- a/app/views/projects/counselings/new.html.erb
+++ b/app/views/projects/counselings/new.html.erb
@@ -20,6 +20,8 @@
       <%= f.text_field :title, min: 1, placeholder: "件名（30字以内）", class: "col-11 form-control counseling-text mb-3", required: true %>
       <%= f.label :counseling_detail, "相談内容", class:"font-weight-bold counseling-title-box" %>
       <%= f.text_area :counseling_detail, min: 1, placeholder: "最大500文字", class: "col-11 form-control counseling-area mb-3",rows: "10", required: true %>
+      <!-- 画像添付 -->
+      <%= render partial: "/projects/images/images_form", locals: { f: f} %>
       <div class="text-center mb-3">
         <%= link_to '戻る', user_project_path(@user,@project),class: "btn btn-secondary col-2" %>
         <%= f.submit "送信", class: "btn col-2 btn-outline-orange" %>

--- a/app/views/projects/counselings/show.html.erb
+++ b/app/views/projects/counselings/show.html.erb
@@ -10,6 +10,8 @@
     <div class="container p-4 card-body">
       <h3 class="font-weight-bold counseling-title-box m-3 d-inline">内容</h3>
       <div class="card-text"><%= simple_format(@counseling.counseling_detail) %></div>
+      <!-- 添付画像の表示 -->
+      <%= render "/projects/images/show_image", object: @counseling %>
       <div id="read_button">
         <%= render partial: 'read' %>
       </div>  
@@ -34,3 +36,6 @@
   <!-- 返信フォームの表示 -->
   <%= render "/projects/counseling_replys/counseling_reply_form" %>
 </div>
+
+<!-- モーダルウィンドウ表示 -->
+<div id="show_image" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>

--- a/app/views/projects/images/_images_form.html.erb
+++ b/app/views/projects/images/_images_form.html.erb
@@ -1,0 +1,10 @@
+<!-- 画像選択 -->
+<label class="reply-image-label">
+  <span class="btn btn-light"><font size="2">📁画像アップロード</font></span>
+  <%= f.file_field :images, multiple: true, accept: 'image/*', class: "reply-image-form", onchange: "preview_images(this)" %>
+</label>
+<div class="images_area">
+  <!-- プレビュー画像が表示される -->
+</div>
+<!-- 画像使用有無 -->
+<%= f.hidden_field :image_enable, id: "hiddenInput", :value => "" %>

--- a/app/views/projects/images/_images_form.html.erb
+++ b/app/views/projects/images/_images_form.html.erb
@@ -5,6 +5,6 @@
 </label>
 <div class="images_area">
   <!-- プレビュー画像が表示される -->
-</div>
+</div><br/>
 <!-- 画像使用有無 -->
 <%= f.hidden_field :image_enable, id: "hiddenInput", :value => "" %>

--- a/app/views/projects/images/_show_image.html.erb
+++ b/app/views/projects/images/_show_image.html.erb
@@ -10,6 +10,8 @@
           <%= link_to image_tag(image, class: "thumbnail"), show_image_user_project_report_report_reply_path(@user,@project,object, image_id: image.id), remote: true %>
         <% when Message %>
           <%= link_to image_tag(image, class: "thumbnail"), show_image_user_project_message_message_reply_path(@user,@project,object, image_id: image.id), remote: true %>
+        <% when Counseling %>
+          <%= link_to image_tag(image, class: "thumbnail"), show_image_user_project_counseling_counseling_reply_path(@user,@project,object, image_id: image.id), remote: true %>
         <% end %>
 
         <% if current_user.id == object.sender_id %>
@@ -20,6 +22,9 @@
                       data: {confirm: "削除してよろしいですか？"} %>
             <% when Message %>
               <%= link_to "削除", delete_image_user_project_message_message_reply_path(@user,@project,object, image_id: image.id), method: :delete, remote: true,
+                      data: {confirm: "削除してよろしいですか？"} %>
+            <% when Counseling %>
+              <%= link_to "削除", delete_image_user_project_counseling_counseling_reply_path(@user,@project,object, image_id: image.id), method: :delete, remote: true,
                       data: {confirm: "削除してよろしいですか？"} %>
             <% end %>
           </div>

--- a/app/views/projects/images/_show_image.html.erb
+++ b/app/views/projects/images/_show_image.html.erb
@@ -8,13 +8,18 @@
         <% case object %>
         <% when Report %>
           <%= link_to image_tag(image, class: "thumbnail"), show_image_user_project_report_report_reply_path(@user,@project,object, image_id: image.id), remote: true %>
+        <% when Message %>
+          <%= link_to image_tag(image, class: "thumbnail"), show_image_user_project_message_message_reply_path(@user,@project,object, image_id: image.id), remote: true %>
         <% end %>
 
-        <% if current_user == @user %>
+        <% if current_user.id == object.sender_id %>
           <div class="reply-image-menu">
             <% case object %>
             <% when Report %>
               <%= link_to "削除", delete_image_user_project_report_report_reply_path(@user,@project,object, image_id: image.id), method: :delete, remote: true,
+                      data: {confirm: "削除してよろしいですか？"} %>
+            <% when Message %>
+              <%= link_to "削除", delete_image_user_project_message_message_reply_path(@user,@project,object, image_id: image.id), method: :delete, remote: true,
                       data: {confirm: "削除してよろしいですか？"} %>
             <% end %>
           </div>

--- a/app/views/projects/images/_show_image.html.erb
+++ b/app/views/projects/images/_show_image.html.erb
@@ -1,0 +1,25 @@
+<% if object.images.count > 0 %>
+  <details open>
+    <summary>
+      <font size="1"><%= object.images.count %>個の画像</font>
+    </summary>
+    <% object.images.each do |image| %>
+      <div class="reply-image-containar">
+        <% case object %>
+        <% when Report %>
+          <%= link_to image_tag(image, class: "thumbnail"), show_image_user_project_report_report_reply_path(@user,@project,object, image_id: image.id), remote: true %>
+        <% end %>
+
+        <% if current_user == @user %>
+          <div class="reply-image-menu">
+            <% case object %>
+            <% when Report %>
+              <%= link_to "削除", delete_image_user_project_report_report_reply_path(@user,@project,object, image_id: image.id), method: :delete, remote: true,
+                      data: {confirm: "削除してよろしいですか？"} %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </details>
+<% end %>

--- a/app/views/projects/messages/new.html.erb
+++ b/app/views/projects/messages/new.html.erb
@@ -24,6 +24,8 @@
       <%= f.text_area :message_detail, min: 1, placeholder: "最大500文字", class: "col-11 form-control message-area mb-3",rows: "6", required: true %>
       <%= f.label :importance, "連絡重要度", class:"font-weight-bold message-title-box" %>
       <%= f.select :importance, [['低', '低'], ['中', '中'], ['高', '高']], { selected: '低' }, prompt: '重要度を選択してください', class: "col-11 form-control message-text mb-3", required: true, id: 'message_importance' %>
+      <!-- 画像添付 -->
+      <%= render partial: "/projects/images/images_form", locals: { f: f} %>
     <div class="text-center mb-3">
       <%= link_to '戻る', :back, class: "btn btn-secondary col-2" %>
       <%= f.submit "送信", class: "btn col-2 btn-outline-orange" %>

--- a/app/views/projects/messages/show.html.erb
+++ b/app/views/projects/messages/show.html.erb
@@ -12,6 +12,8 @@
       <div class="card-text"><%= simple_format(@message.message_detail) %></div>
       <h3 class="font-weight-bold message-title-box m-3 d-inline">連絡重要度</h3>
       <div class="card-text"><%= simple_format(@message.importance) %></div>
+      <!-- 添付画像の表示 -->
+      <%= render "/projects/images/show_image", object: @message %>
       <div id="read_button">
         <%= render partial: 'read' %>
       </div>  
@@ -36,3 +38,6 @@
   <!-- 返信フォームの表示 -->
   <%= render "/projects/message_replys/message_reply_form" %>
 </div>
+
+<!-- モーダルウィンドウ表示 -->
+<div id="show_image" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>

--- a/app/views/projects/reports/_report_form.html.erb
+++ b/app/views/projects/reports/_report_form.html.erb
@@ -77,6 +77,8 @@
       <% end %>
     <% end %>
     <% end %>
+    <!-- 画像添付 -->
+    <%= render partial: "/projects/images/images_form", locals: { f: rf} %>
   <div class="text-right mr-4">
     <%= rf.submit '投稿', class: "btn btn-outline-orange" %><br>
   </div>

--- a/app/views/projects/reports/show.html.erb
+++ b/app/views/projects/reports/show.html.erb
@@ -128,5 +128,5 @@ function changeForm() {
   </div>
 </div>
 
- <!-- モーダルウィンドウ表示 -->
- <div id="show_image" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>
+<!-- モーダルウィンドウ表示 -->
+<div id="show_image" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>

--- a/app/views/projects/reports/show.html.erb
+++ b/app/views/projects/reports/show.html.erb
@@ -101,6 +101,9 @@ function changeForm() {
           <% end %>
         </div>
         <% end %>
+        <!-- 添付画像の表示 -->
+        <%= render "/projects/images/show_image", object: @report %>
+
         <% if current_user == @user %>
           <div class="text-right mr-4">
             <%= link_to "編集", edit_user_project_report_path(@user, @project, @report), class: "btn btn-light btn-outline-orange col-2" %>
@@ -124,3 +127,6 @@ function changeForm() {
     <%= render "/projects/report_replys/report_reply_form" %>
   </div>
 </div>
+
+ <!-- モーダルウィンドウ表示 -->
+ <div id="show_image" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true"></div>


### PR DESCRIPTION
### 概要
・報告新規作成時の画像添付機能追加
・連絡新規作成時の画像添付機能追加
・相談新規作成時の画像添付機能追加

### タスク
- [ ] なし
- [x] あり _(タスクのリンクがあれば貼る)_
・機能分類No.245：報告新規投稿時に画像を添付できる
・機能分類No.246：連絡新規投稿時に画像を添付できる
・機能分類No.247：相談新規投稿時に画像を添付できる

### 実装内容・手法
⇨ 返信機能実装時に使用したActive Storageの機能を用いて実装。

報告・連絡・相談の各モデル（Report / Message / Counseling）に対して、
Imageモデルを関連付け。

⇨ 返信機能の動作詳細は、以下の画面設計書を参照（※返信機能の画像添付と同等の機能）
https://docs.google.com/spreadsheets/d/1zZuioWUIBcg-FuWLLUdkpbVa4anMRSBjtn2VGlLcIsM/edit#gid=1132669412&range=A120
⇨ 返信機能と同様、報告・連絡・相談の編集ページからの画像の追加、削除は不可。
（※ Slackに倣った仕様としているため）


### 実装画像などあれば添付する
◾️報告新規作成
<img width="1426" alt="スクリーンショット 2024-03-20 13 35 49" src="https://github.com/SUZUKI-KOUICHIROU/ho_ren_so_app/assets/102929281/bffdeaf3-2c0e-4058-8bee-807c55e79a78">
◾️連絡新規作成
<img width="1431" alt="スクリーンショット 2024-03-20 14 26 22" src="https://github.com/SUZUKI-KOUICHIROU/ho_ren_so_app/assets/102929281/5547a109-dcc8-415a-b190-54663021d07d">
◾️相談新規作成
<img width="1434" alt="スクリーンショット 2024-03-20 14 26 11" src="https://github.com/SUZUKI-KOUICHIROU/ho_ren_so_app/assets/102929281/e2cf1249-d8e6-4e92-83e9-76431e9d838f">


◾️報告詳細
<img width="1431" alt="スクリーンショット 2024-03-20 15 02 17" src="https://github.com/SUZUKI-KOUICHIROU/ho_ren_so_app/assets/102929281/527a1072-0d23-4242-98d6-b84e429c4fcb">
◾️連絡詳細
<img width="1420" alt="スクリーンショット 2024-03-20 15 02 40" src="https://github.com/SUZUKI-KOUICHIROU/ho_ren_so_app/assets/102929281/b756acdc-33d3-4f04-86d2-89024343c378">
◾️相談詳細
<img width="1430" alt="スクリーンショット 2024-03-20 15 03 21" src="https://github.com/SUZUKI-KOUICHIROU/ho_ren_so_app/assets/102929281/3e7f590a-7eb2-49d0-9273-10ac7a3bb773">


### gemfileの変更
- [x] なし
- [ ] あり 
