### PR TITLE
Feat/report remind model rspec

### DIFF
--- a/app/models/project_user.rb
+++ b/app/models/project_user.rb
@@ -13,8 +13,12 @@ class ProjectUser < ApplicationRecord
 
   # 報告リマインダーに対し、設定ボタンの押下日＆選択時刻をカラム保存するメソッド
   def set_report_reminder_time(report_time)
-    report_time = Time.zone.parse(report_time)
-    self.report_reminder_time = report_time.in_time_zone('Asia/Tokyo')
+    if report_time.present?
+      report_time = Time.zone.parse(report_time)
+      self.report_reminder_time = report_time.in_time_zone('Asia/Tokyo')
+    else
+      raise ArgumentError, "Invalid report time: #{report_time}"
+    end
 
     save!
 

--- a/app/views/projects/members/index.html.erb
+++ b/app/views/projects/members/index.html.erb
@@ -103,7 +103,7 @@
                       <input type="checkbox" class="custom-control-input" id="customSwitch<%= member.id %>" data-member-id="<%= member.id %>" data-user-id="<%= @user.id %>" data-project-id="<%= @project.id %>">
                       <label class="custom-control-label" for="customSwitch<%= member.id %>"></label>
                     </div>
-                      <div class="form-group reminder-setting" style="display: none;">
+                    <div class="form-group reminder-setting" style="display: none;">
                       <!--報告リマインドの日にち選択ドロップダウン（プロジェクトリーダー用／未設定の場合）-->
                       <select class="form-control" id="reminderDays<%= member.id %>" disabled></select>
                       <label for="reminderDays<%= member.id %>">の</label>

--- a/spec/factories/project_user.rb
+++ b/spec/factories/project_user.rb
@@ -1,6 +1,6 @@
 # FactoryBot.define do
-  # factory :project_user do
-    # association :user
-    # association :project
-  # end
+# factory :project_user do
+# association :user
+# association :project
+# end
 # end

--- a/spec/factories/project_user.rb
+++ b/spec/factories/project_user.rb
@@ -1,6 +1,6 @@
-FactoryBot.define do
-  factory :project_user do
-    association :user
-    association :project
-  end
-end
+# FactoryBot.define do
+  # factory :project_user do
+    # association :user
+    # association :project
+  # end
+# end

--- a/spec/factories/project_users.rb
+++ b/spec/factories/project_users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :project_user do
+    
+  end
+end

--- a/spec/factories/project_users.rb
+++ b/spec/factories/project_users.rb
@@ -1,5 +1,17 @@
 FactoryBot.define do
   factory :project_user do
-    
+    association :user, factory: :unique_user
+    association :project
+
+    member_expulsion { false } # member_expulsion のデフォルト値を指定
+  end
+end
+
+FactoryBot.define do
+  factory :unique_user, class: 'User' do
+    name { Faker::Name.name } # ランダムな名前を生成
+    email { Faker::Internet.unique.email } # ランダムなメールアドレスを生成
+    password { 'password' }
+    password_confirmation { 'password' }
   end
 end

--- a/spec/factories/project_users.rb
+++ b/spec/factories/project_users.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
       report_time { Time.zone.now.strftime('%H:%M:%S') }
 
       # 未実装のdequeue_report_reminderメソッドをテスト保留させる処理（実装後は要・修正or削除）
-      after(:create) do |project_user|
+      after(:build) do |project_user|
         allow(project_user).to receive(:dequeue_report_reminder).and_return(nil)
       end
     end

--- a/spec/factories/project_users.rb
+++ b/spec/factories/project_users.rb
@@ -9,10 +9,16 @@ FactoryBot.define do
     reminder_days { nil } # 選択日数カラムのデフォルト値を指定
     report_time { nil } # 選択時刻カラムのデフォルト値を指定
 
-    trait :with_reminder do
+    trait :with_reminder do # テストジョブ用のサンプルデータを作成
       report_reminder_time { Time.zone.now }
+      reminder_enabled { true }
       reminder_days { 1 }
       report_time { Time.zone.now.strftime('%H:%M:%S') }
+
+      # 未実装のdequeue_report_reminderメソッドをテスト保留させる処理（実装後は要・修正or削除）
+      after(:create) do |project_user|
+        allow(project_user).to receive(:dequeue_report_reminder).and_return(nil)
+      end
     end
   end
 end

--- a/spec/factories/project_users.rb
+++ b/spec/factories/project_users.rb
@@ -3,8 +3,11 @@ FactoryBot.define do
     association :user, factory: :unique_user
     association :project
 
-    member_expulsion { false } # member_expulsion のデフォルト値を指定
-    report_reminder_time { nil } # report_reminder_time のデフォルト値を指定
+    member_expulsion { false } # メンバー除外カラムのデフォルト値を指定
+    report_reminder_time { nil } # 設定日＆選択時刻カラムのデフォルト値を指定
+    reminder_enabled { false } # リマインダー有効無効カラムのデフォルト値を指定
+    reminder_days { nil } # 選択日数カラムのデフォルト値を指定
+    report_time { nil } # 選択時刻カラムのデフォルト値を指定
   end
 end
 

--- a/spec/factories/project_users.rb
+++ b/spec/factories/project_users.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     reminder_days { nil } # 選択日数カラムのデフォルト値を指定
     report_time { nil } # 選択時刻カラムのデフォルト値を指定
 
-    trait :with_reminder do # テストジョブ用のサンプルデータを作成
+    trait :with_reminder do # テストジョブ用のサンプルパターン
       report_reminder_time { Time.zone.now }
       reminder_enabled { true }
       reminder_days { 1 }
@@ -19,6 +19,10 @@ FactoryBot.define do
       after(:build) do |project_user|
         allow(project_user).to receive(:dequeue_report_reminder).and_return(nil)
       end
+    end
+
+    trait :member_expulsion_true do # メンバー除外カラムをtrueにするサンプルパターン
+      member_expulsion { true }
     end
   end
 end

--- a/spec/factories/project_users.rb
+++ b/spec/factories/project_users.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     association :project
 
     member_expulsion { false } # member_expulsion のデフォルト値を指定
+    report_reminder_time { nil } # report_reminder_time のデフォルト値を指定
   end
 end
 

--- a/spec/factories/project_users.rb
+++ b/spec/factories/project_users.rb
@@ -8,6 +8,12 @@ FactoryBot.define do
     reminder_enabled { false } # リマインダー有効無効カラムのデフォルト値を指定
     reminder_days { nil } # 選択日数カラムのデフォルト値を指定
     report_time { nil } # 選択時刻カラムのデフォルト値を指定
+
+    trait :with_reminder do
+      report_reminder_time { Time.zone.now }
+      reminder_days { 1 }
+      report_time { Time.zone.now.strftime('%H:%M:%S') }
+    end
   end
 end
 

--- a/spec/models/project_user_spec.rb
+++ b/spec/models/project_user_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ProjectUser, type: :model do
   describe 'set_report_reminder_timeメソッドのテスト' do
     let(:project_user) { FactoryBot.create(:project_user) }
 
-    context '有効な報告時刻を指定した場合' do
+    context '有効なリマインド時刻を指定した場合' do
       it '報告リマインダー時刻を正しく設定できる' do
         report_time = Time.zone.now.to_s # 文字列に変換
         project_user.set_report_reminder_time(report_time)
@@ -53,10 +53,31 @@ RSpec.describe ProjectUser, type: :model do
       end
     end
 
-    context '無効な報告時刻を指定した場合' do
-      it 'report_timeが空の場合は報告時刻を設定できない' do
-        invalid_report_time = nil # 無効な報告時刻の例
+    context '無効なリマインド時刻を指定した場合' do
+      it 'report_timeが空の場合はリマインド時刻を設定できない' do
+        invalid_report_time = nil # 空のリマインド時刻を設定
         expect { project_user.set_report_reminder_time(invalid_report_time) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe 'calculate_reminder_datetimeメソッドのテスト' do
+    let(:project_user) { FactoryBot.create(:project_user) }
+    let(:reminder_days) { 1 } # テスト選択日数を1（日前）に設定
+    let(:report_time) { "09:00:00" } # テスト選択時刻を午前9時に設定
+    let(:next_report_date) { Date.current + 1 } # テスト次回報告日を翌日に設定
+
+    context '選択日数が正の整数の場合' do
+      it '選択日数分を差し引いた日時が指定日時として設定されること' do
+        reminder_datetime = project_user.calculate_reminder_datetime(reminder_days, report_time, next_report_date)
+        expect(reminder_datetime).to eq(Time.zone.local(next_report_date.year, next_report_date.month, next_report_date.day, 9, 0, 0) - 1.day)
+      end
+    end
+
+    context '選択日数が0の場合' do
+      it '指定日時がそのまま設定されること' do
+        reminder_datetime = project_user.calculate_reminder_datetime(0, report_time, next_report_date)
+        expect(reminder_datetime).to eq(Time.zone.local(next_report_date.year, next_report_date.month, next_report_date.day, 9, 0, 0))
       end
     end
   end

--- a/spec/models/project_user_spec.rb
+++ b/spec/models/project_user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ProjectUser, type: :model do
-  subject(:project_user) { FactoryBot.create(:project_user) } # テストプロジェクトユーザーの作成
+  subject(:project_user) { FactoryBot.build(:project_user) } # テストプロジェクトユーザーの作成
   let(:project) { project_user.project } # プロジェクトへの割当て
   let(:members) { project.users } # メンバーへの割当て
 
@@ -70,7 +70,7 @@ RSpec.describe ProjectUser, type: :model do
   end
 
   describe 'queue_report_reminderメソッドのテスト' do
-    let(:user) { FactoryBot.create(:unique_user) }
+    let(:user) { FactoryBot.build(:unique_user) }
     let(:reminder_days) { 1 }
     let(:report_time) { Time.zone.now.to_s }
     let(:report_frequency) { 7 }

--- a/spec/models/project_user_spec.rb
+++ b/spec/models/project_user_spec.rb
@@ -1,5 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe ProjectUser, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  describe 'member_expulsion_joinメソッドのテスト' do
+    context '各メンバーに正しく除外ステータスを割り当てる' do
+      it '除外したメンバーには除外ステータスが割り当てられる' do
+        # テストプロジェクトの作成
+        project = FactoryBot.create(:project)
+    
+        # テストユーザーの作成
+        member1 = FactoryBot.create(:unique_user)
+        member2 = FactoryBot.create(:unique_user)
+        
+        # テストプロジェクトへのメンバー関連付け
+        project_user1 = FactoryBot.create(:project_user, project: project, user: member1)
+        project_user2 = FactoryBot.create(:project_user, project: project, user: member2)
+
+        # 除外ステータスの設定
+        project_user1.update(member_expulsion: true)
+        project_user2.update(member_expulsion: false)
+        
+        # メンバー配列の作成
+        members = [member1, member2]
+        
+        # member_expulsion_joinメソッドの呼び出し
+        ProjectUser.member_expulsion_join(project, members)
+  
+        # 各メンバーの除外ステータスを再度取得して検証
+        members.each(&:reload)
+      
+        # メンバーのmember_expulsionメソッドが正しい設定かを検証
+        expect(members[0].member_expulsion).to eq(true)
+        expect(members[1].member_expulsion).to eq(false)
+    
+      end
+    end
+  end
 end

--- a/spec/models/project_user_spec.rb
+++ b/spec/models/project_user_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe ProjectUser, type: :model do
         reminder_days = 1
         report_frequency = 7
 
-        # キューにジョブが追加されることを確認
+        # キューにジョブが追加される
         expect {
           project_user = project.project_users.find_by(user_id: user.id)
           project_user.queue_report_reminder(project.id, user.id, report_frequency, reminder_days, report_time)
@@ -119,11 +119,22 @@ RSpec.describe ProjectUser, type: :model do
         reminder_days = 1
         report_frequency = 7
 
-        # キューにジョブが追加されないことを確認
+        # キューにジョブが追加されない
         expect { 
           project_user = project.project_users.find_by(user_id: user.id)
           project_user.queue_report_reminder(project.id, user.id, report_frequency, reminder_days, report_time) 
         }.to raise_error(ArgumentError, /Invalid report time:/)
+      end
+    end
+  end
+
+  describe 'dequeue_report_reminderメソッドのテスト' do
+    context 'キューから報告リマインダージョブを削除する場合' do
+      it 'キューからジョブが削除される（メソッド未実装につきテスト保留中＆実装後は要・修正）' do
+        project_user = FactoryBot.create(:project_user)
+
+        # 未実装中メソッドを呼び出してもエラーを発生させない処理（実装後は要・修正）
+        expect { project_user.dequeue_report_reminder }.not_to raise_error
       end
     end
   end

--- a/spec/models/project_user_spec.rb
+++ b/spec/models/project_user_spec.rb
@@ -1,15 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe ProjectUser, type: :model do
-  describe '計算' do
-    context '10 + 10の場合' do
-      it '20になること' do
-       expect(10 + 10).to eq 20
-      end
-
-      it '30にはならない' do
-       expect(10 + 10).not_to eq 30
-      end
-    end
-  end
+  pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/project_user_spec.rb
+++ b/spec/models/project_user_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe ProjectUser, type: :model do
+  let(:project) { FactoryBot.create(:project) } # テストプロジェクトの作成
+  let(:member1) { FactoryBot.create(:unique_user) } # テストユーザー１の作成
+  let(:member2) { FactoryBot.create(:unique_user) } # テストユーザー２の作成
+  let(:project_user1) { FactoryBot.create(:project_user, project: project, user: member1) } # ユーザー１のプロジェクト関連付け
+  let(:project_user2) { FactoryBot.create(:project_user, project: project, user: member2) } # ユーザー２のプロジェクト関連付け
+  let(:members) { [member1, member2] } # メンバー配列の作成
+
   before do
     # ActiveJobのキューアダプターをテスト用に設定
     ActiveJob::Base.queue_adapter = :test
@@ -9,133 +16,89 @@ RSpec.describe ProjectUser, type: :model do
   describe 'member_expulsion_joinメソッドのテスト' do
     context 'メンバーを正しく除外した場合' do
       it '除外したメンバーには除外ステータスが割り当てられる' do
-        # テストプロジェクトの作成
-        project = FactoryBot.create(:project)
-    
-        # テストユーザーの作成
-        member1 = FactoryBot.create(:unique_user)
-        member2 = FactoryBot.create(:unique_user)
-        
-        # テストプロジェクトへのメンバー関連付け
-        project_user1 = FactoryBot.create(:project_user, project: project, user: member1)
-        project_user2 = FactoryBot.create(:project_user, project: project, user: member2)
+        project_user1.update(member_expulsion: true) # 除外ステータスを付与
+        project_user2.update(member_expulsion: false) # 除外ステータスを付与しない
 
-        # 除外ステータスの設定
-        project_user1.update(member_expulsion: true)
-        project_user2.update(member_expulsion: false)
-        
-        # メンバー配列の作成
-        members = [member1, member2]
-        
-        # member_expulsion_joinメソッドの呼び出し
         ProjectUser.member_expulsion_join(project, members)
-  
-        # 各メンバーの除外ステータスを再度取得して検証
-        members.each(&:reload)
-      
-        # メンバーのmember_expulsionメソッドが正しい設定かを検証
+
+        members.each(&:reload) # 各メンバーの除外ステータスを再度取得して検証
+
         expect(members[0].member_expulsion).to eq(true)
         expect(members[1].member_expulsion).to eq(false)
-    
       end
     end
   end
 
   describe 'set_report_reminder_timeメソッドのテスト' do
     let(:project_user) { FactoryBot.create(:project_user) }
+    let(:report_time) { Time.zone.now.to_s }
 
     context 'リマインド時刻を選択した場合' do
       it '報告リマインダー時刻を正しく設定できる' do
-        report_time = Time.zone.now.to_s # 文字列に変換
         project_user.set_report_reminder_time(report_time)
         expect(project_user.reload.report_reminder_time).to eq(report_time.in_time_zone('Asia/Tokyo'))
       end
 
       it 'プロジェクトユーザーを保存する' do
-        report_time = Time.zone.now.to_s # 文字列に変換
         expect { project_user.set_report_reminder_time(report_time) }.to change { project_user.reload.report_reminder_time }.from(nil).to(report_time.in_time_zone('Asia/Tokyo'))
       end
     end
 
     context 'リマインド時刻を選択しなかった場合' do
       it 'report_timeが空の場合はリマインド時刻を設定できない' do
-        invalid_report_time = nil # 空のリマインド時刻を設定
-        expect { project_user.set_report_reminder_time(invalid_report_time) }.to raise_error(ArgumentError)
+        expect { project_user.set_report_reminder_time(nil) }.to raise_error(ArgumentError)
       end
     end
   end
 
   describe 'calculate_reminder_datetimeメソッドのテスト' do
     let(:project_user) { FactoryBot.create(:project_user) }
-    let(:reminder_days) { 1 } # テスト選択日数を1（日前）に設定
-    let(:report_time) { "09:00:00" } # テスト選択時刻を午前9時に設定
-    let(:next_report_date) { Date.current + 1 } # テスト次回報告日を翌日に設定
+    let(:next_report_date) { Date.current + 1 }
 
     context '選択日数が正の整数の場合' do
       it '次回報告日から選択日数分を差し引いた日時が指定日時として設定される' do
-        reminder_datetime = project_user.calculate_reminder_datetime(reminder_days, report_time, next_report_date)
+        reminder_datetime = project_user.calculate_reminder_datetime(1, '09:00:00', next_report_date)
         expect(reminder_datetime).to eq(Time.zone.local(next_report_date.year, next_report_date.month, next_report_date.day, 9, 0, 0) - 1.day)
       end
     end
 
     context '選択日数が0の場合' do
       it '次回報告日がそのまま指定日時として設定される' do
-        reminder_datetime = project_user.calculate_reminder_datetime(0, report_time, next_report_date)
+        reminder_datetime = project_user.calculate_reminder_datetime(0, '09:00:00', next_report_date)
         expect(reminder_datetime).to eq(Time.zone.local(next_report_date.year, next_report_date.month, next_report_date.day, 9, 0, 0))
       end
     end
   end
 
   describe 'queue_report_reminderメソッドのテスト' do
+    let(:project_user) { FactoryBot.create(:project_user) }
+    let(:user) { FactoryBot.create(:unique_user) }
+    let(:reminder_days) { 1 }
+    let(:report_time) { Time.zone.now.to_s }
+    let(:report_frequency) { 7 }
+
     context '有効な報告リマインド日時を設定した場合' do
       it '報告リマインダーのジョブがキューに追加される' do
-        # テスト用のプロジェクトとユーザーを作成
-        project = FactoryBot.create(:project)
-        user = FactoryBot.create(:unique_user)
         user.projects << project
 
-        # リマインダーの設定（有効な時刻を指定）
-        report_time = Time.zone.now.to_s
-        reminder_days = 1
-        report_frequency = 7
-
-        # キューにジョブが追加される
         expect {
-          project_user = project.project_users.find_by(user_id: user.id)
           project_user.queue_report_reminder(project.id, user.id, report_frequency, reminder_days, report_time)
-        }.to change { ActiveJob::Base.queue_adapter.enqueued_jobs.size }.by_at_least(1) # キューに1つ以上追加されることを確認
+        }.to change { ActiveJob::Base.queue_adapter.enqueued_jobs.size }.by_at_least(1)
       end
     end
 
     context '無効な報告リマインド日時を設定した場合' do
       it 'report_timeが空の場合はジョブがキュー追加されない' do
-        # テスト用のプロジェクトとユーザーを作成
-        project = FactoryBot.create(:project)
-        user = FactoryBot.create(:unique_user)
-        user.projects << project
-
-        # リマインダーの設定（無効な時刻を指定）
-        report_time = nil
-        reminder_days = 1
-        report_frequency = 7
-
-        # キューにジョブが追加されない
-        expect { 
-          project_user = project.project_users.find_by(user_id: user.id)
-          project_user.queue_report_reminder(project.id, user.id, report_frequency, reminder_days, report_time) 
-        }.to raise_error(ArgumentError, /Invalid report time:/)
+        expect { project_user.queue_report_reminder(project.id, user.id, report_frequency, reminder_days, nil) }.to raise_error(ArgumentError, /Invalid report time:/)
       end
     end
   end
 
   describe 'dequeue_report_reminderメソッドのテスト' do
-    context 'キューから報告リマインダージョブを削除する場合' do
-      it 'キューからジョブが削除される（メソッド未実装につきテスト保留中＆実装後は要・修正）' do
-        project_user = FactoryBot.create(:project_user)
+    it 'キューからジョブが削除される（メソッド未実装につきテスト保留中＆実装後は要・修正）' do
+      project_user = FactoryBot.create(:project_user)
 
-        # 未実装中メソッドを呼び出してもエラーを発生させない処理（実装後は要・修正）
-        expect { project_user.dequeue_report_reminder }.not_to raise_error
-      end
+      expect { project_user.dequeue_report_reminder }.not_to raise_error
     end
   end
 end

--- a/spec/models/project_user_spec.rb
+++ b/spec/models/project_user_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe ProjectUser, type: :model do
+  describe '計算' do
+    context '10 + 10の場合' do
+      it '20になること' do
+       expect(10 + 10).to eq 20
+      end
+
+      it '30にはならない' do
+       expect(10 + 10).not_to eq 30
+      end
+    end
+  end
+end

--- a/spec/models/project_user_spec.rb
+++ b/spec/models/project_user_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ProjectUser, type: :model do
 
   describe 'member_expulsion_joinメソッドのテスト' do
-    context '各メンバーに正しく除外ステータスを割り当てる' do
+    context 'メンバーを正しく除外した場合' do
       it '除外したメンバーには除外ステータスが割り当てられる' do
         # テストプロジェクトの作成
         project = FactoryBot.create(:project)
@@ -33,6 +33,30 @@ RSpec.describe ProjectUser, type: :model do
         expect(members[0].member_expulsion).to eq(true)
         expect(members[1].member_expulsion).to eq(false)
     
+      end
+    end
+  end
+
+  describe 'set_report_reminder_timeメソッドのテスト' do
+    let(:project_user) { FactoryBot.create(:project_user) }
+
+    context '有効な報告時刻を指定した場合' do
+      it '報告リマインダー時刻を正しく設定できる' do
+        report_time = Time.zone.now.to_s # 文字列に変換
+        project_user.set_report_reminder_time(report_time)
+        expect(project_user.reload.report_reminder_time).to eq(report_time.in_time_zone('Asia/Tokyo'))
+      end
+
+      it 'プロジェクトユーザーを保存する' do
+        report_time = Time.zone.now.to_s # 文字列に変換
+        expect { project_user.set_report_reminder_time(report_time) }.to change { project_user.reload.report_reminder_time }.from(nil).to(report_time.in_time_zone('Asia/Tokyo'))
+      end
+    end
+
+    context '無効な報告時刻を指定した場合' do
+      it 'report_timeが空の場合は報告時刻を設定できない' do
+        invalid_report_time = nil # 無効な報告時刻の例
+        expect { project_user.set_report_reminder_time(invalid_report_time) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/models/project_user_spec.rb
+++ b/spec/models/project_user_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe ProjectUser, type: :model do
+  before do
+    # ActiveJobのキューアダプターをテスト用に設定
+    ActiveJob::Base.queue_adapter = :test
+  end
 
   describe 'member_expulsion_joinメソッドのテスト' do
     context 'メンバーを正しく除外した場合' do
@@ -40,7 +44,7 @@ RSpec.describe ProjectUser, type: :model do
   describe 'set_report_reminder_timeメソッドのテスト' do
     let(:project_user) { FactoryBot.create(:project_user) }
 
-    context '有効なリマインド時刻を指定した場合' do
+    context 'リマインド時刻を選択した場合' do
       it '報告リマインダー時刻を正しく設定できる' do
         report_time = Time.zone.now.to_s # 文字列に変換
         project_user.set_report_reminder_time(report_time)
@@ -53,7 +57,7 @@ RSpec.describe ProjectUser, type: :model do
       end
     end
 
-    context '無効なリマインド時刻を指定した場合' do
+    context 'リマインド時刻を選択しなかった場合' do
       it 'report_timeが空の場合はリマインド時刻を設定できない' do
         invalid_report_time = nil # 空のリマインド時刻を設定
         expect { project_user.set_report_reminder_time(invalid_report_time) }.to raise_error(ArgumentError)
@@ -68,16 +72,58 @@ RSpec.describe ProjectUser, type: :model do
     let(:next_report_date) { Date.current + 1 } # テスト次回報告日を翌日に設定
 
     context '選択日数が正の整数の場合' do
-      it '選択日数分を差し引いた日時が指定日時として設定されること' do
+      it '次回報告日から選択日数分を差し引いた日時が指定日時として設定される' do
         reminder_datetime = project_user.calculate_reminder_datetime(reminder_days, report_time, next_report_date)
         expect(reminder_datetime).to eq(Time.zone.local(next_report_date.year, next_report_date.month, next_report_date.day, 9, 0, 0) - 1.day)
       end
     end
 
     context '選択日数が0の場合' do
-      it '指定日時がそのまま設定されること' do
+      it '次回報告日がそのまま指定日時として設定される' do
         reminder_datetime = project_user.calculate_reminder_datetime(0, report_time, next_report_date)
         expect(reminder_datetime).to eq(Time.zone.local(next_report_date.year, next_report_date.month, next_report_date.day, 9, 0, 0))
+      end
+    end
+  end
+
+  describe 'queue_report_reminderメソッドのテスト' do
+    context '有効な報告リマインド日時を設定した場合' do
+      it '報告リマインダーのジョブがキューに追加される' do
+        # テスト用のプロジェクトとユーザーを作成
+        project = FactoryBot.create(:project)
+        user = FactoryBot.create(:unique_user)
+        user.projects << project
+
+        # リマインダーの設定（有効な時刻を指定）
+        report_time = Time.zone.now.to_s
+        reminder_days = 1
+        report_frequency = 7
+
+        # キューにジョブが追加されることを確認
+        expect {
+          project_user = project.project_users.find_by(user_id: user.id)
+          project_user.queue_report_reminder(project.id, user.id, report_frequency, reminder_days, report_time)
+        }.to change { ActiveJob::Base.queue_adapter.enqueued_jobs.size }.by_at_least(1) # キューに1つ以上追加されることを確認
+      end
+    end
+
+    context '無効な報告リマインド日時を設定した場合' do
+      it 'report_timeが空の場合はジョブがキュー追加されない' do
+        # テスト用のプロジェクトとユーザーを作成
+        project = FactoryBot.create(:project)
+        user = FactoryBot.create(:unique_user)
+        user.projects << project
+
+        # リマインダーの設定（無効な時刻を指定）
+        report_time = nil
+        reminder_days = 1
+        report_frequency = 7
+
+        # キューにジョブが追加されないことを確認
+        expect { 
+          project_user = project.project_users.find_by(user_id: user.id)
+          project_user.queue_report_reminder(project.id, user.id, report_frequency, reminder_days, report_time) 
+        }.to raise_error(ArgumentError, /Invalid report time:/)
       end
     end
   end


### PR DESCRIPTION
### 概要
報告リマインダー関連のRspec（モデルスペック）実装

### タスク
- [ ] なし
- [x] あり _(タスクのリンクがあれば貼る)_

・報告リマインド関連テスト：Rspecモデルスペック（プロジェクトユーザーモデル）

### 実装内容・手法
＜既存ファイルへの追記＆編集＞
①spec\factories\project_user.rb（既存FactoryBotファイル）にて、重複回避の為の全コメントアウト化。

＜新規ファイルの生成＞
①spec\models\project_user_spec.rbにて、プロジェクトユーザーモデル用specファイルを生成＆実装。
②spec\factories\project_users.rbにて、プロジェクトユーザーモデル用の正しいFactoryBotファイルを生成＆実装。

※プロジェクトユーザーモデル内のdequeue_report_reminderメソッドは
　Redis＋Sidekiq導入後に本実装予定の為、
　同モデル用specファイル＆FactoryBotファイルに記述した同メソッド用テスト実装は仮実装。

### 実装画像などあれば添付する

### gemfileの変更
- [x] なし
- [ ] あり 
