### PR TITLE
報告履歴のcsvエクスポート、検索のタイムゾーン修正

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -32,7 +32,9 @@ class Report < ApplicationRecord
     reports
   end
 
-  scope :created_at, ->(created_at) { where('created_at BETWEEN ? AND ?', "#{created_at} 00:00:00", "#{created_at} 23:59:59") }
+  scope :created_at, ->(created_at) { 
+    where("created_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo' BETWEEN ? AND ?", "#{created_at} 00:00:00", "#{created_at} 23:59:59") 
+  }
   scope :keywords_like, ->(keywords) {
     left_joins(:answers) # `answers`テーブルとのLEFT JOINを使用することで、answersテーブルにエントリがないreportsも検索結果に含めることができる。
       .where(

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -32,8 +32,8 @@ class Report < ApplicationRecord
     reports
   end
 
-  scope :created_at, ->(created_at) { 
-    where("created_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo' BETWEEN ? AND ?", "#{created_at} 00:00:00", "#{created_at} 23:59:59") 
+  scope :created_at, ->(created_at) {
+    where("created_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo' BETWEEN ? AND ?", "#{created_at} 00:00:00", "#{created_at} 23:59:59")
   }
   scope :keywords_like, ->(keywords) {
     left_joins(:answers) # `answers`テーブルとのLEFT JOINを使用することで、answersテーブルにエントリがないreportsも検索結果に含めることができる。

--- a/app/views/projects/reports/history.html.erb
+++ b/app/views/projects/reports/history.html.erb
@@ -9,6 +9,15 @@
   <div class="d-flex justify-content-end mb-3">
     <%= link_to "報告一覧", user_project_reports_path, class: "btn btn-outline-orange" %>
   </div>
+  <div class="d-flex justify-content-start mb-3">
+    <% if params[:search].present? && params[:search] != "" %>
+      <%= link_to "csvエクスポート", history_user_project_report_path(format: :csv, search: @reports_by_search), class: "btn btn-outline-orange" %>
+    <% elsif params[:month].present? %>
+      <%= link_to "csvエクスポート", history_user_project_report_path(format: :csv, month: params[:month]), class: "btn btn-outline-orange" %>
+    <% else %>
+      <%= link_to "csvエクスポート", history_user_project_report_path(format: :csv), class: "btn btn-outline-orange" %>
+    <% end %>
+  </div>
   <% if @report_history.present? %>
     <div class="d-flex justify-content-between mb-3">
       <div class="align-self-end">


### PR DESCRIPTION
### 概要
①報告履歴のcsvエクスポート機能実装。
②報告一覧・履歴の検索時のタイムゾーン修正。

### タスク
- [ ] なし
- [x] あり _(タスクのリンクがあれば貼る)_
①報告履歴のcsvエクスポート
https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit#gid=1075510033&range=A106

②検索時のタイムゾーン修正
https://docs.google.com/spreadsheets/d/1qitHpAxSv65lzMyIFgvnDUr-YLbd484bAfxjEI1SDeo/edit#gid=0&range=A36

### 実装内容・手法
①csvエクスポート･･･連絡履歴を参考に実装。
　出力内容は「報告者、件名、報告日」の３項目。
　月選択、報告日検索、キーワード検索の結果も反映し、出力する。
②タイムゾーン修正･･･report.rbファイルの scope :created_at の部分のコードを修正。

### 実装画像などあれば添付する
csvエクスポート（更新済みの画面設計書）
https://docs.google.com/spreadsheets/d/1zZuioWUIBcg-FuWLLUdkpbVa4anMRSBjtn2VGlLcIsM/edit#gid=2039177054&range=A1

### gemfileの変更
- [x] なし
- [ ] あり 
