### PR TITLE
テキストエリア内のURL有効化

### DIFF
--- a/app/assets/stylesheets/report.scss
+++ b/app/assets/stylesheets/report.scss
@@ -275,7 +275,6 @@
     padding: 0;
     font-weight: bold;
     font-size: 0.8em;
-    white-space: pre-wrap;
   }
 }
 .textlines {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,6 +48,7 @@ module ApplicationHelper
 
   # テキスト内のURLを自動的にリンクに変換する。また、改行を有効化する。
   def format_text(text)
-    raw Rinku.auto_link(simple_format(text), :urls, 'target="_blank" rel="noopener noreferrer"')
+    link_text = Rinku.auto_link(simple_format(text), :urls, 'target="_blank" rel="noopener noreferrer"')
+    sanitize(link_text, tags: %w(a p br), attributes: %w(href target rel))        # サニタイズして必要なタグと属性を許可
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,4 +45,9 @@ module ApplicationHelper
       'success'
     end
   end
+
+  # テキスト内のURLを自動的にリンクに変換する。また、改行を有効化する。
+  def format_text(text)
+    raw Rinku.auto_link(simple_format(text), :urls, 'target="_blank" rel="noopener noreferrer"')
+  end
 end

--- a/app/views/projects/counseling_replys/_counseling_reply_show.html.erb
+++ b/app/views/projects/counseling_replys/_counseling_reply_show.html.erb
@@ -1,6 +1,6 @@
 <div class="reply-text">
   <!-- 返信本文 -->
-  <p><%= reply.reply_content %></p>
+  <p><%= format_text(reply.reply_content) %></p>
 </div>
 <!-- 添付画像 -->
 <% if reply.images.count > 0 %>

--- a/app/views/projects/counselings/show.html.erb
+++ b/app/views/projects/counselings/show.html.erb
@@ -9,7 +9,7 @@
     </div>
     <div class="container p-4 card-body">
       <h3 class="font-weight-bold counseling-title-box m-3 d-inline">内容</h3>
-      <div class="card-text"><%= simple_format(@counseling.counseling_detail) %></div>
+      <div class="card-text"><%= format_text(@counseling.counseling_detail) %></div>
       <!-- 添付画像の表示 -->
       <%= render "/projects/images/show_image", object: @counseling %>
       <div id="read_button">

--- a/app/views/projects/message_replys/_message_reply_show.html.erb
+++ b/app/views/projects/message_replys/_message_reply_show.html.erb
@@ -1,6 +1,6 @@
 <div class="reply-text">
   <!-- 返信本文 -->
-  <p><%= reply.reply_content %></p>
+  <p><%= format_text(reply.reply_content) %></p>
 </div>
 <!-- 添付画像 -->
 <% if reply.images.count > 0 %>

--- a/app/views/projects/messages/show.html.erb
+++ b/app/views/projects/messages/show.html.erb
@@ -9,7 +9,7 @@
     </div>
     <div class="container p-4 card-body">
       <h3 class="font-weight-bold message-title-box m-3 d-inline">内容</h3>
-      <div class="card-text"><%= simple_format(@message.message_detail) %></div>
+      <div class="card-text"><%= format_text(@message.message_detail) %></div>
       <h3 class="font-weight-bold message-title-box m-3 d-inline">連絡重要度</h3>
       <div class="card-text"><%= simple_format(@message.importance) %></div>
       <!-- 添付画像の表示 -->

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -21,7 +21,7 @@
       <% end %>
       
       <div class="text-secondary">概要</div>
-      <p class="card-text"><%= @project.description %></p>
+      <div class="card-text"><%= format_text(@project.description) %></div>
     
       <div class="text-secondary">リーダー</div>
       <p class="card-text"><%= User.find(@project.leader_id).name %></p>

--- a/app/views/projects/report_replys/_report_reply_show.html.erb
+++ b/app/views/projects/report_replys/_report_reply_show.html.erb
@@ -1,6 +1,6 @@
 <div class="reply-text">
   <!-- 返信本文 -->
-  <p><%= reply.reply_content %></p>
+  <p><%= format_text(reply.reply_content) %></p>
 </div>
 <!-- 添付画像 -->
 <% if reply.images.count > 0 %>

--- a/app/views/projects/reports/_edit_date_field.html.erb
+++ b/app/views/projects/reports/_edit_date_field.html.erb
@@ -5,7 +5,7 @@
     <br>
     <% if !answer.value.blank? %>
       <div class="card-text ml-0">
-        <%= raw Rinku.auto_link(answer.value, :all, 'target="_blank"') %>
+        <%= format_text(answer.value) %>
       </div>
     <% else %>
       <div class="card-text ml-0">

--- a/app/views/projects/reports/_edit_radio_button.html.erb
+++ b/app/views/projects/reports/_edit_radio_button.html.erb
@@ -4,7 +4,7 @@
     <br>
     <% if !answer.value.blank? %>
       <div class="card-text ml-0">
-        <%= raw Rinku.auto_link(answer.value, :all, 'target="_blank"') %>
+        <%= format_text(answer.value) %>
       </div>
     <% else %>
       <div class="card-text ml-0">

--- a/app/views/projects/reports/_edit_select.html.erb
+++ b/app/views/projects/reports/_edit_select.html.erb
@@ -5,7 +5,7 @@
     <br>
     <% if !answer.value.blank? %>
       <div class="card-text ml-0">
-        <%= raw Rinku.auto_link(answer.value, :all, 'target="_blank"') %>
+        <%= format_text(answer.value) %>
       </div>
     <% else %>
       <div class="card-text ml-0">

--- a/app/views/projects/reports/_edit_text_area.html.erb
+++ b/app/views/projects/reports/_edit_text_area.html.erb
@@ -4,7 +4,7 @@
     <br>
     <% if !answer.value.blank? %>
       <div class="card-text ml-0">
-        <%= raw Rinku.auto_link(answer.value, :all, 'target="_blank"') %>
+        <%= format_text(answer.value) %>
       </div>
     <% else %>
       <div class="card-text ml-0">

--- a/app/views/projects/reports/_edit_text_field.html.erb
+++ b/app/views/projects/reports/_edit_text_field.html.erb
@@ -5,7 +5,7 @@
     <br>
     <% if !answer.value.blank? %>
       <div class="card-text ml-0">
-        <%= raw Rinku.auto_link(answer.value, :all, 'target="_blank"') %>
+        <%= format_text(answer.value) %>
       </div>
     <% else %>
       <div class="card-text ml-0">

--- a/app/views/projects/reports/show.html.erb
+++ b/app/views/projects/reports/show.html.erb
@@ -92,7 +92,7 @@ function changeForm() {
               <% end %>
           <% elsif !answer.value.blank? %>
             <div class="card-text ml-0">
-              <%= raw Rinku.auto_link(answer.value, :all, 'target="_blank"') %>
+              <%= format_text(answer.value) %>
             </div>
           <% else %>
             <div class="card-text ml-0">


### PR DESCRIPTION
### 概要
報告・連絡・相談における各テキストフォーム内のURLを有効化（リンク化）する。

### タスク
- [ ] なし
- [x] あり _([詳細設計：No.252〜258](https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit?gid=1075510033#gid=1075510033&range=A249))_

### 実装内容・手法
テキスト表示処理をメソッド化し、報告・連絡・相談の表示方法を統一した。
このメソッド内で、
 ・改行の有効化（simple_format）
 ・リンクの有効化（auto_link）
 ・XSS対策（sanitize）
をまとめて行う。

### 修正箇所
修正対応の該当箇所は以下。
 ・報告詳細
 ・報告返信
 ・連絡詳細
 ・連絡返信
 ・報告詳細
 ・報告返信
 ・プロジェクト詳細

### gemfileの変更
- [x] なし
- [ ] あり 
⇨ rinku のgemは既に導入済みだったため、変更なし。
