### PR TITLE
不具合対応「問題表31：全プロジェクト報告集計画面でのリンク表示」

### DIFF
--- a/app/controllers/projects/reports_controller.rb
+++ b/app/controllers/projects/reports_controller.rb
@@ -138,7 +138,7 @@ class Projects::ReportsController < Projects::BaseProjectController
         ["rate_week#{@n}".to_sym, "#{one_week_reports_rate}%"]
       end
       overall_reporting_rate_array = [[:overall_reporting_rate, "#{overall_report_rate_calc(@four_weeks_report_rate_array)}%"]]
-      link_status = project_mender_or_admin?(@user, project)
+      link_status = project_leader?(@user, project)
       project_date_array = [[:project_name, project.name], [:id, project.id], [:created_at, project.created_at], [:link_on, link_status]]
       project_array = report_rate_for_each_four_weeks + project_date_array + overall_reporting_rate_array
       project_array.to_h
@@ -329,9 +329,9 @@ class Projects::ReportsController < Projects::BaseProjectController
     return (project_four_weeks_reports_size.quo(7 * members.size).to_f * 100).floor
   end
 
-  # プロジェクトメンバーかスタッフかを判断する
-  def project_mender_or_admin?(user, project)
-    if user.project_users.find_by(project_id: project.id).present? || user.admin
+  # プロジェクトリーダーかを判断する
+  def project_leader?(current_user, project)
+    if current_user.id == project.leader_id
       return true
     else
       return false


### PR DESCRIPTION
### 概要
全プロジェクト報告集計で、報告集計画面へのアクセス権限が無いユーザーはリンクで表示せず、
各プロジェクトのリーダーのみ、該当プロジェクトをリンクで表示するように修正。

### タスク
- [ ] なし
- [x] あり _(タスクのリンクがあれば貼る)_
問題表No.31
https://docs.google.com/spreadsheets/d/1qitHpAxSv65lzMyIFgvnDUr-YLbd484bAfxjEI1SDeo/edit?gid=0#gid=0&range=A32

### 実装内容・手法
reports_controller.rbの「project_mender_or_admin?」メソッドを
「project_leader?」メソッドに変更し、プロジェクトリーダーかを判断する内容に修正。

詳細設計の全プロジェクト集計画面に関わる箇所の中項目(権限)を修正。
No.102
https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit?gid=1075510033#gid=1075510033&range=A108

### 実装画像などあれば添付する

### gemfileの変更
- [x] なし
- [ ] あり 
