### PR TITLE
連絡一覧の検索結果なしﾌﾗｯｼｭﾒｯｾｰｼﾞ表示修正

### DIFF
--- a/app/views/projects/messages/index.html.erb
+++ b/app/views/projects/messages/index.html.erb
@@ -4,6 +4,12 @@
   <%= render partial: 'layouts/sidebar' , locals: { user: @user, project: @project } %>
 <% end %>
 
+<div id="flash-messages">
+  <% flash.each do |key, message| %>
+    <div class="alert alert-<%= key %>"><%= message %></div>
+  <% end %>
+</div>
+
 <div class="card-box">  
   <p class="project-name-text">プロジェクト：<%= @project.name %></p>  
   <h1 class="text-center">連絡一覧</h1>

--- a/app/views/projects/messages/index.js.erb
+++ b/app/views/projects/messages/index.js.erb
@@ -1,5 +1,10 @@
-<% if flash.now[:danger].present? %>
-  alert('<%= flash.now[:danger] %>');
+<% if flash.now[:danger] %>
+  $("#flash-messages").html('<div class="alert alert-danger"><%= j flash.now[:danger] %></div>');
+  setTimeout(function() {
+    $(".alert-danger").hide("fast", function() { // フラッシュメッセージを非表示
+      $(this).remove(); // 非表示後に要素をDOMから削除
+    });
+  }, 5000); // 5000ミリ秒（5秒）後に非表示
 <% end %>
 $("#you-addressee-messages-container").html("<%= escape_javascript(render partial: 'projects/messages/you_addressee_messages', locals: { messages: @you_addressee_messages }) %>");
 $("#you-send-messages-container").html("<%= escape_javascript(render partial: 'projects/messages/you_send_messages', locals: { messages: @you_send_messages }) %>");


### PR DESCRIPTION
### 概要
連絡一覧画面の検索結果なしのフラッシュメッセージの表示方法を
報告一覧画面と同様にする。

### タスク
- [ ] なし
- [x] あり _(タスクのリンクがあれば貼る)_
タスク
https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit?gid=1058469562#gid=1058469562&range=B44

アプリ問題表No.33
https://docs.google.com/spreadsheets/d/1qitHpAxSv65lzMyIFgvnDUr-YLbd484bAfxjEI1SDeo/edit?gid=0#gid=0&range=A34

### 実装内容・手法
messages/index.html.erbとmessages/index.js.erbファイルにフラッシュメッセージを表示するコードを追加、修正。
messages/index.js.erbファイルに「setTimeout()」メソッドを追加し、5秒後に自動で非表示になる処理を実装。

### 実装画像などあれば添付する

### gemfileの変更
- [x] なし
- [ ] あり 
