### PR TITLE
RSpec(モデルスペック) 報告作成時、未読になるテスト実装

### DIFF
--- a/spec/factories/reports.rb
+++ b/spec/factories/reports.rb
@@ -9,5 +9,6 @@ FactoryBot.define do
     report_day { Date.current }
     created_at { Date.current }
     updated_at { Date.current }
+    report_read_flag { false }
   end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -25,5 +25,12 @@ RSpec.describe Report, type: :model do
         expect(build(:report, sender_name: '')).to be_invalid
       end
     end
+
+    context 'report_read_flagカラム' do
+      it '報告作成時、報告確認状況(report_read_flag)が未読(false)になる' do
+        report = FactoryBot.build(:report)
+        expect(report.report_read_flag).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
### 概要
RSpec実装。
報告作成時、未読になるテスト（モデルスペック）

### タスク
- [ ] なし
- [x] あり _(タスクのリンクがあれば貼る)_
https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit?gid=1058469562#gid=1058469562&range=B37

### 実装内容・手法
「spec/factories/reports.rb」に report_read_flagカラムの記述を追加。
「spec/models/reoprt_spec.rb」に '報告作成時、報告確認状況が未読になるテスト'を追加。

### 実装画像などあれば添付する

### gemfileの変更
- [x] なし
- [ ] あり 
