### PR TITLE
Feat/counseling rspec

### DIFF
--- a/spec/models/counseling_spec.rb
+++ b/spec/models/counseling_spec.rb
@@ -2,4 +2,34 @@ require 'rails_helper'
 
 RSpec.describe Counseling, type: :model do
   subject(:message) { FactoryBot.build(:message) }
+
+  describe 'counselingの登録' do
+    context '相談の送信' do
+      before(:each) do
+        # テスト用のプロジェクトを作成し、インスタンス変数に格納
+        @project = create(:project)
+      end
+      it '送信相手、件名、相談内容があれば送信できる' do
+        expect(build(:counseling, title: 'test', counseling_detail: 'test', send_to_all: true)).to be_valid
+      end
+      it 'titleがなければ送信できない' do
+        expect(build(:counseling, title: '')).to be_invalid
+      end
+      it '件名が31文字以上は送信できない' do
+        expect(build(:counseling, title: 'a' * 31)).to be_invalid
+      end
+      it '相談内容がなければ送信できない' do
+        expect(build(:counseling, counseling_detail: '')).to be_invalid
+      end
+      it '501文字以上は投稿できない' do
+        expect(build(:counseling, counseling_detail: 'a' * 501)).to be_invalid
+      end
+    end
+
+    context '送信相手' do
+      it '送信相手が空の場合は送信できない' do
+        expect(build(:counseling, send_to_all: 'false' && :counseling, send_to: '')).to be_invalid
+      end
+    end
+  end
 end

--- a/spec/models/counseling_spec.rb
+++ b/spec/models/counseling_spec.rb
@@ -3,17 +3,17 @@ require 'rails_helper'
 RSpec.describe Counseling, type: :model do
   subject(:message) { FactoryBot.build(:message) }
 
-  describe 'counselingの登録' do # describeはテスト主題
-    context '相談の送信' do # 条件
+  describe 'counselingの登録' do
+    context '相談の送信' do
       before(:each) do
         # テスト用のプロジェクトを作成し、インスタンス変数に格納
-        @project = create(:project) # これは本ファイルの他のテストでもプロジェクト作成を適用させるためのもの
+        @project = create(:project)
       end
-      it '送信相手、件名、相談内容があれば送信できる' do # it テスト内容の題名
+      it '送信相手、件名、相談内容があれば送信できる' do
         expect(build(:counseling, title: 'test', counseling_detail: 'test', send_to_all: true)).to be_valid # expect:期待値 to_be_valid:期待した結果になる(true)
       end
       it 'titleがなければ送信できない' do
-        expect(build(:counseling, title: '')).to be_invalid # to_be_invalid:falseになる
+        expect(build(:counseling, title: '')).to be_invalid
       end
       it '件名が31文字以上は送信できない' do
         expect(build(:counseling, title: 'a' * 31)).to be_invalid

--- a/spec/models/counseling_spec.rb
+++ b/spec/models/counseling_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Counseling, type: :model do
-  subject(:message) { FactoryBot.build(:message) }
+  subject(:counseling) { FactoryBot.build(:counseling) }
 
   describe 'counselingの登録' do
     context '相談の送信' do

--- a/spec/models/counseling_spec.rb
+++ b/spec/models/counseling_spec.rb
@@ -3,17 +3,17 @@ require 'rails_helper'
 RSpec.describe Counseling, type: :model do
   subject(:message) { FactoryBot.build(:message) }
 
-  describe 'counselingの登録' do
-    context '相談の送信' do
+  describe 'counselingの登録' do # describeはテスト主題
+    context '相談の送信' do # 条件
       before(:each) do
         # テスト用のプロジェクトを作成し、インスタンス変数に格納
-        @project = create(:project)
+        @project = create(:project) # これは本ファイルの他のテストでもプロジェクト作成を適用させるためのもの
       end
-      it '送信相手、件名、相談内容があれば送信できる' do
-        expect(build(:counseling, title: 'test', counseling_detail: 'test', send_to_all: true)).to be_valid
+      it '送信相手、件名、相談内容があれば送信できる' do # it テスト内容の題名
+        expect(build(:counseling, title: 'test', counseling_detail: 'test', send_to_all: true)).to be_valid # expect:期待値 to_be_valid:期待した結果になる(true)
       end
       it 'titleがなければ送信できない' do
-        expect(build(:counseling, title: '')).to be_invalid
+        expect(build(:counseling, title: '')).to be_invalid # to_be_invalid falseになる
       end
       it '件名が31文字以上は送信できない' do
         expect(build(:counseling, title: 'a' * 31)).to be_invalid
@@ -30,6 +30,13 @@ RSpec.describe Counseling, type: :model do
       it '送信相手が空の場合は送信できない' do
         expect(build(:counseling, send_to_all: 'false' && :counseling, send_to: '')).to be_invalid
       end
+    end
+  end
+
+  describe '相談検索' do
+    let(:search_params) { { keywords: 'example' } }
+    it '検索が空で実行された場合、全相談を表示する' do
+      expect(Counseling.search({})).to eq(Counseling.all)
     end
   end
 end

--- a/spec/models/counseling_spec.rb
+++ b/spec/models/counseling_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Counseling, type: :model do
         expect(build(:counseling, title: 'test', counseling_detail: 'test', send_to_all: true)).to be_valid # expect:期待値 to_be_valid:期待した結果になる(true)
       end
       it 'titleがなければ送信できない' do
-        expect(build(:counseling, title: '')).to be_invalid # to_be_invalid falseになる
+        expect(build(:counseling, title: '')).to be_invalid # to_be_invalid:falseになる
       end
       it '件名が31文字以上は送信できない' do
         expect(build(:counseling, title: 'a' * 31)).to be_invalid
@@ -34,9 +34,18 @@ RSpec.describe Counseling, type: :model do
   end
 
   describe '相談検索' do
-    let(:search_params) { { keywords: 'example' } }
+    let(:search_params) { { keywords: 'example' } } # search_paramsにexampleというkeywordを入れている
     it '検索が空で実行された場合、全相談を表示する' do
-      expect(Counseling.search({})).to eq(Counseling.all)
+      expect(Counseling.search({})).to eq(Counseling.all) # 空で検索し全て表示されることを期待している
+    end
+
+    it '検索したキーワードを含むキーワードがあれば、検索キーワードが入った相談を表示する' do
+      allow(Counseling).to receive(:where).with("title LIKE :keyword OR counseling_detail LIKE :keyword",
+        keyword: "%#{search_params[:keywords]}%").and_call_original
+      # modelでのｶｽﾀﾑｽｺｰﾌﾟ定義がないためmessages_spec.rbのように:keywords_likeは使用できない
+      # そのため:whereを使用
+      # 「where」メソッドが使われるときに、「title」や「counseling_detail」に「example」というキーワードが含まれているかを確認している
+      Counseling.search(search_params)
     end
   end
 end

--- a/spec/models/counseling_spec.rb
+++ b/spec/models/counseling_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Counseling, type: :model do
+  subject(:message) { FactoryBot.build(:message) }
+end


### PR DESCRIPTION
### 概要
RSpec実装：相談機能（モデルスペック）完了
※rspecエラーなし確認済　構文エラーなし確認済
7/22 counseling_spec.rb subject以下の定義 message → counseling へ修正

### タスク
- [ ] なし
- [x] あり https://docs.google.com/spreadsheets/d/13gLhBRmXqtZu4EBsfG-Jq9vD32EhqQzGTKOQlgkpb4U/edit?usp=sharing

### 実装内容・手法
message_spec.rbを参考に実装

### gemfileの変更
- [x] なし
- [ ] あり 
