### PR TITLE
問題表37：相談・連絡作成画面で文字数制限以上の文字を入力し送信しても「送信先を選択してください」と表示される

### DIFF
--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -69,8 +69,7 @@ class Projects::CounselingsController < Projects::BaseProjectController
         flash[:success] = "相談内容を送信しました。"
         redirect_to user_project_path current_user, params[:project_id]
       else
-        flash[:danger] = "送信相手を選択してください。"
-        render action: :new
+        log_and_render_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
       end
     else
       # TO ALLが選択されていない時
@@ -84,8 +83,7 @@ class Projects::CounselingsController < Projects::BaseProjectController
         flash[:success] = "相談内容を送信しました。"
         redirect_to user_project_path current_user, params[:project_id]
       else
-        flash[:danger] = "送信相手を選択してください。"
-        render action: :new
+        log_and_render_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
       end
     end
   end
@@ -130,6 +128,13 @@ class Projects::CounselingsController < Projects::BaseProjectController
 
   def counseling_params
     params.require(:counseling).permit(:counseling_detail, :title, { send_to: [] }, :send_to_all, images: [])
+  end
+
+  def log_and_render_errors # ｴﾗｰを表示
+    if @counseling.errors.full_messages.present? # counselingのerrorが存在する時
+      flash[:danger] = @counseling.errors.full_messages.join(", ") # ｴﾗｰのﾒｯｾｰｼﾞを表示 複数ある時は連結して表示
+    end
+    render action: :new
   end
 
   def counseling_search_params

--- a/app/models/counseling.rb
+++ b/app/models/counseling.rb
@@ -3,7 +3,6 @@ class Counseling < ApplicationRecord
   has_many :counseling_confirmers, dependent: :destroy
   has_many :counseling_replies, dependent: :destroy
   has_many_attached :images, dependent: :destroy
-
   attr_accessor :send_to
 
   attribute :send_to_all
@@ -11,7 +10,8 @@ class Counseling < ApplicationRecord
   validates :title, presence: true, length: { maximum: 30 }
   validates :counseling_detail, presence: true, length: { maximum: 500 }
   # validates :counseling_reply_flag, inclusion: [true, false]
-  validate :no_check_become_invalid
+  # validate :no_check_become_invalid
+  validate :send_to_must_be_present, unless: :send_to_all? # ｵﾘｼﾞﾅﾙﾊﾞﾘﾃﾞｰｼｮﾝ:送信先の存在が必要ﾒｿｯﾄﾞ 全員送信を選択している時はｽｷｯﾌﾟ
 
   # ログインユーザー宛のメッセージを取得
   def self.my_counselings(user)
@@ -30,14 +30,14 @@ class Counseling < ApplicationRecord
     User.where(id: buf)
   end
 
-  # 送信相手を一名以上選択しているか。
-  def no_check_become_invalid
-    unless send_to_all
-      if send_to.nil?
-        errors.add "", "送信相手を選択してください。"
-      end
-    end
-  end
+  # # 送信相手を一名以上選択しているか。
+  # def no_check_become_invalid
+  #   unless send_to_all
+  #     if send_to.nil?
+  #       errors.add "", "送信相手を選択してください。"
+  #     end
+  #   end
+  # end
 
   # 検索機能
   def self.search(search_params)
@@ -47,5 +47,21 @@ class Counseling < ApplicationRecord
       query = query.where("title LIKE :keyword OR counseling_detail LIKE :keyword", keyword: keyword)
     end
     query
+  end
+
+  def send_to_all?
+    ActiveRecord::Type::Boolean.new.cast(send_to_all)
+    # ActiveRecordの型ｷｬｽﾃｨﾝｸﾞ（型変換）を扱うｸﾗｽ
+    # cast 引数をﾌﾞｰﾙ値に変換
+    # このﾒｿｯﾄﾞは、send_to_all属性の値をﾌﾞｰﾙ値に変換して返す。
+    # send_to_all属性が文字列や数値などの形式で保存されている場合でも、ﾌﾞｰﾙ値として扱えるようにする
+  end
+
+  private
+
+  def send_to_must_be_present # 送信先の存在が必要ﾒｿｯﾄﾞ
+    if send_to.blank? # 送信先がない、空の場合
+      errors.add(:send_to, "を選択してください") # 送信先を選択してくださいのｴﾗｰﾒｯｾｰｼﾞを追加
+    end
   end
 end

--- a/config/locales/models/models_ja.yml
+++ b/config/locales/models/models_ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activerecord:
+    models:
+      counseling: 相談
+    attributes:
+        counseling:
+          title: 件名
+          counseling_detail: 相談内容
+          send_to: 送信相手
+          


### PR DESCRIPTION
### 概要
相談作成の際、バリデーションメッセージが表示されない不具合対応について修正いたしました。
同様症状の連絡作成については相談作成の内容確認・マージ完了後に対応いたします。

### タスク
- [ ] なし
- [x] あり https://docs.google.com/spreadsheets/d/13gLhBRmXqtZu4EBsfG-Jq9vD32EhqQzGTKOQlgkpb4U/edit?usp=sharing

### 実装内容・手法
フラッシュメッセージが表示される箇所をエラーメッセージが表示されるメソッドへ変更
chatGPTに大分助けてもらいました。

### gemfileの変更
- [x] なし
- [ ] あり 
