### PR TITLE
問題表37：相談・連絡作成画面で文字数制限以上の文字を入力し送信しても「送信先を選択してください」と表示される　※連絡

### DIFF
--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -112,7 +112,6 @@ class Projects::MessagesController < Projects::BaseProjectController
     if @message.errors.full_messages.present? # messageのerrorが存在する時
       flash[:danger] = @message.errors.full_messages.join(", ") # ｴﾗｰのﾒｯｾｰｼﾞを表示 複数ある時は連結して表示
     end
-    render action: :new
   end
 
 
@@ -211,6 +210,7 @@ class Projects::MessagesController < Projects::BaseProjectController
       redirect_to user_project_messages_path(current_user, params[:project_id])
     else
       log_and_render_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
+      render :new
     end
   end
 

--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -234,7 +234,7 @@ class Projects::MessagesController < Projects::BaseProjectController
       flash[:success] = "連絡内容を更新し、送信しました。"
       redirect_to user_project_messages_path(current_user, params[:project_id])
     else
-      flash[:danger] = "送信相手を選択してください。"
+      log_and_render_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
       render :edit
     end
   end

--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -114,7 +114,6 @@ class Projects::MessagesController < Projects::BaseProjectController
     end
   end
 
-
   # 全員の連絡
   def all_messages
     Message.monthly_messages_for(@project).order(created_at: 'DESC').page(params[:messages_page]).per(5)

--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -108,6 +108,14 @@ class Projects::MessagesController < Projects::BaseProjectController
 
   private
 
+  def log_and_render_errors # ｴﾗｰを表示
+    if @message.errors.full_messages.present? # messageのerrorが存在する時
+      flash[:danger] = @message.errors.full_messages.join(", ") # ｴﾗｰのﾒｯｾｰｼﾞを表示 複数ある時は連結して表示
+    end
+    render action: :new
+  end
+
+
   # 全員の連絡
   def all_messages
     Message.monthly_messages_for(@project).order(created_at: 'DESC').page(params[:messages_page]).per(5)
@@ -202,8 +210,7 @@ class Projects::MessagesController < Projects::BaseProjectController
       flash[:success] = "連絡内容を送信しました."
       redirect_to user_project_messages_path(current_user, params[:project_id])
     else
-      flash[:danger] = "送信相手を選択してください."
-      render action: :new
+      log_and_render_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
     end
   end
 

--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -108,7 +108,7 @@ class Projects::MessagesController < Projects::BaseProjectController
 
   private
 
-  def log_and_render_errors # ｴﾗｰを表示
+  def log_errors # ｴﾗｰを表示
     if @message.errors.full_messages.present? # messageのerrorが存在する時
       flash[:danger] = @message.errors.full_messages.join(", ") # ｴﾗｰのﾒｯｾｰｼﾞを表示 複数ある時は連結して表示
     end
@@ -208,7 +208,7 @@ class Projects::MessagesController < Projects::BaseProjectController
       flash[:success] = "連絡内容を送信しました."
       redirect_to user_project_messages_path(current_user, params[:project_id])
     else
-      log_and_render_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
+      log_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
       render :new
     end
   end
@@ -233,7 +233,7 @@ class Projects::MessagesController < Projects::BaseProjectController
       flash[:success] = "連絡内容を更新し、送信しました。"
       redirect_to user_project_messages_path(current_user, params[:project_id])
     else
-      log_and_render_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
+      log_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
       render :edit
     end
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -9,7 +9,6 @@ class Message < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 30 }
   validates :message_detail, presence: true, length: { maximum: 500 }
-  # validate :no_check_become_invalid
   validate :send_to_must_be_present, unless: :send_to_all? # ｵﾘｼﾞﾅﾙﾊﾞﾘﾃﾞｰｼｮﾝ:送信先の存在が必要ﾒｿｯﾄﾞ 全員送信を選択している時はｽｷｯﾌﾟ
 
   def set_importance(importance, recipients)
@@ -38,16 +37,6 @@ class Message < ApplicationRecord
     buf = message_confirmers.where(message_confirmation_flag: true).select('message_confirmer_id')
     User.where(id: buf)
   end
-
-  # 送信相手にTO ALLを選択していない場合
-  # 送信相手を一名以上選択しているか。
-  # def no_check_become_invalid
-  #   unless send_to_all
-  #     if send_to.nil?
-  #       errors.add "", "送信相手を選択してください。"
-  #     end
-  #   end
-  # end
 
   # 月次連絡を取得する
   def self.monthly_messages_for(project)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -11,7 +11,6 @@ class Message < ApplicationRecord
   validates :message_detail, presence: true, length: { maximum: 500 }
   # validate :no_check_become_invalid
   validate :send_to_must_be_present, unless: :send_to_all? # ｵﾘｼﾞﾅﾙﾊﾞﾘﾃﾞｰｼｮﾝ:送信先の存在が必要ﾒｿｯﾄﾞ 全員送信を選択している時はｽｷｯﾌﾟ
- 
 
   def set_importance(importance, recipients)
     self.importance = importance

--- a/config/locales/models/models_ja.yml
+++ b/config/locales/models/models_ja.yml
@@ -1,10 +1,14 @@
 ja:
   activerecord:
     models:
+      message: 連絡
       counseling: 相談
     attributes:
+        message:
+          title: 件名
+          message_detail: 連絡内容
+          send_to: 送信相手
         counseling:
           title: 件名
           counseling_detail: 相談内容
           send_to: 送信相手
-          


### PR DESCRIPTION
### 概要
連絡作成の際、バリデーションメッセージが表示されない不具合対応について修正いたしました。
なお、連絡編集の際も同様の症状があったためそちらも併せて修正しました。

### タスク
- [x] なし
- [ ] あり　https://docs.google.com/spreadsheets/d/13gLhBRmXqtZu4EBsfG-Jq9vD32EhqQzGTKOQlgkpb4U/edit?usp=sharing

### 実装内容・手法
相談作成の不具合修正同様、フラッシュメッセージが表示される箇所をエラーメッセージが表示されるメソッドへ変更

### gemfileの変更
- [x] なし
- [ ] あり 
