### PR TITLE
問題表37：相談・連絡作成画面で文字数制限以上の文字を入力し送信しても「送信先を選択してください」と表示される　※相談再修正

### DIFF
--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -70,6 +70,7 @@ class Projects::CounselingsController < Projects::BaseProjectController
         redirect_to user_project_path current_user, params[:project_id]
       else
         log_and_render_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
+        render :new
       end
     else
       # TO ALLが選択されていない時
@@ -84,6 +85,7 @@ class Projects::CounselingsController < Projects::BaseProjectController
         redirect_to user_project_path current_user, params[:project_id]
       else
         log_and_render_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
+        render :new
       end
     end
   end
@@ -134,7 +136,6 @@ class Projects::CounselingsController < Projects::BaseProjectController
     if @counseling.errors.full_messages.present? # counselingのerrorが存在する時
       flash[:danger] = @counseling.errors.full_messages.join(", ") # ｴﾗｰのﾒｯｾｰｼﾞを表示 複数ある時は連結して表示
     end
-    render action: :new
   end
 
   def counseling_search_params

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -69,7 +69,7 @@ class Projects::CounselingsController < Projects::BaseProjectController
         flash[:success] = "相談内容を送信しました。"
         redirect_to user_project_path current_user, params[:project_id]
       else
-        log_and_render_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
+        log_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
         render :new
       end
     else
@@ -84,7 +84,7 @@ class Projects::CounselingsController < Projects::BaseProjectController
         flash[:success] = "相談内容を送信しました。"
         redirect_to user_project_path current_user, params[:project_id]
       else
-        log_and_render_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
+        log_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
         render :new
       end
     end
@@ -101,8 +101,8 @@ class Projects::CounselingsController < Projects::BaseProjectController
       flash[:success] = "相談内容を更新しました。"
       redirect_to user_project_counselings_path
     else
-      flash[:danger] = "送信相手を選択してください。"
-      render action: :edit
+      log_errors # ｴﾗｰを表示するﾒｿｯﾄﾞ
+      render :edit
     end
   end
 
@@ -132,7 +132,7 @@ class Projects::CounselingsController < Projects::BaseProjectController
     params.require(:counseling).permit(:counseling_detail, :title, { send_to: [] }, :send_to_all, images: [])
   end
 
-  def log_and_render_errors # ｴﾗｰを表示
+  def log_errors # ｴﾗｰを表示
     if @counseling.errors.full_messages.present? # counselingのerrorが存在する時
       flash[:danger] = @counseling.errors.full_messages.join(", ") # ｴﾗｰのﾒｯｾｰｼﾞを表示 複数ある時は連結して表示
     end


### PR DESCRIPTION
### 概要
　既に修正しました相談作成の際、バリデーションメッセージが表示されない不具合対応について、ﾒｿｯﾄﾞ名の変更及び相談編集時も同様の症状があったため修正いたしました。

### タスク
- [x] なし
- [ ] あり https://docs.google.com/spreadsheets/d/13gLhBRmXqtZu4EBsfG-Jq9vD32EhqQzGTKOQlgkpb4U/edit?usp=sharing

### gemfileの変更
- [x] なし
- [ ] あり 
