### PR TITLE
問題表30：ユーザー削除時の紐付き情報（他メンバーの報告編集）修正完了

### DIFF
--- a/app/controllers/projects/reports_controller.rb
+++ b/app/controllers/projects/reports_controller.rb
@@ -2,6 +2,8 @@ class Projects::ReportsController < Projects::BaseProjectController
   require 'csv'
   before_action :project_authorization, only: %i[index show new edit create update destroy]
   before_action :project_leader_user, only: %i[view_reports_log view_reports_log_month]
+  before_action :set_report, only: %i[edit update destroy]
+  before_action :authorize_user!, only: %i[edit update destroy]
 
   def index
     set_project_and_members
@@ -202,6 +204,17 @@ class Projects::ReportsController < Projects::BaseProjectController
   end
 
   private
+
+  def set_report
+    @report = Report.find(params[:id])
+  end
+
+  def authorize_user!
+    unless current_user.id == @report.id
+      flash[:alert] = "アクセス権限がありません"
+      redirect_to root_path
+    end
+  end
 
   # フォーム新規登録並びに編集用/create
   def create_reports_params

--- a/app/views/projects/reports/show.html.erb
+++ b/app/views/projects/reports/show.html.erb
@@ -104,7 +104,7 @@ function changeForm() {
         <!-- 添付画像の表示 -->
         <%= render "/projects/images/show_image", object: @report %>
 
-        <% if current_user == @user %>
+        <% if current_user == @user && current_user.id == @report.user_id %>
           <div class="text-right mr-4">
             <%= link_to "編集", edit_user_project_report_path(@user, @project, @report), class: "btn btn-light btn-outline-orange col-3" %>
           </div>


### PR DESCRIPTION
### 概要
問題表30：ユーザー削除時の紐付き情報（他メンバーの報告編集）の修正が完了しました。
なお、報告以外にもURL直打ちにより削除されたユーザーの連絡、相談編集画面に遷移できるため、こちら承認されたあとにそちらも修正しようと思います。

### タスク
- [x] なし
- [ ] あり https://docs.google.com/spreadsheets/d/13gLhBRmXqtZu4EBsfG-Jq9vD32EhqQzGTKOQlgkpb4U/edit?usp=sharing

### 実装内容・手法
編集ボタン表示は@report.user_idと同じじゃないと表示されないように修正 併せてコントローラーでメソッド追加しbefore_actionを追加

### gemfileの変更
- [x] なし
- [ ] あり 
