### PR TITLE
問題表30：ユーザー削除時の紐付き情報（他メンバーの報告編集）※他メンバーの連絡、相談編集URL直打制限　修正完了

### DIFF
--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -1,5 +1,6 @@
 class Projects::CounselingsController < Projects::BaseProjectController
   before_action :project_authorization
+  before_action :authorize_user!, only: %i[edit update destroy]
 
   def index
     set_project_and_members
@@ -135,6 +136,15 @@ class Projects::CounselingsController < Projects::BaseProjectController
   def log_errors # ｴﾗｰを表示
     if @counseling.errors.full_messages.present? # counselingのerrorが存在する時
       flash[:danger] = @counseling.errors.full_messages.join(", ") # ｴﾗｰのﾒｯｾｰｼﾞを表示 複数ある時は連結して表示
+    end
+  end
+
+  def authorize_user!
+    counseling = @project.counselings.find(params[:id])
+    unless current_user.id == counseling.sender_id
+      flash[:alert] = "アクセス権限がありません"
+      redirect_to user_project_counselings_path(@user, @project)
+      # redirect先をrootとするとﾘﾀﾞｲﾚｸﾄﾙｰﾌﾟ発生するため相談一覧とした
     end
   end
 

--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -3,6 +3,7 @@ class Projects::MessagesController < Projects::BaseProjectController
   require 'csv'
   before_action :project_authorization
   before_action :my_message, only: %i[show]
+  before_action :authorize_user!, only: %i[edit update destroy]
 
   def index
     @user = User.find(params[:user_id])
@@ -107,6 +108,14 @@ class Projects::MessagesController < Projects::BaseProjectController
   end
 
   private
+
+  def authorize_user!
+    message = @project.messages.find(params[:id])
+    unless current_user.id == message.sender_id
+      flash[:alert] = "アクセス権限がありません"
+      redirect_to user_project_messages_path(@user, @project)
+    end
+  end
 
   def log_errors # ｴﾗｰを表示
     if @message.errors.full_messages.present? # messageのerrorが存在する時


### PR DESCRIPTION
### 概要
問題表30：ユーザー削除時の紐付き情報（他メンバーの報告編集）
　※他メンバーの連絡、相談編集URL直打画面遷移制限について修正が完了しました。

### タスク
- [ ] なし
- [x] あり https://docs.google.com/spreadsheets/d/13gLhBRmXqtZu4EBsfG-Jq9vD32EhqQzGTKOQlgkpb4U/edit?usp=sharing

### 実装内容・手法
編集制限ﾒｿｯﾄﾞ追加（before_action含む）

### gemfileの変更
- [x] なし
- [ ] あり 
