### PR TITLE
問題表36：報告・連絡の投稿が0件の場合に履歴ページへのボタンを押すとエラーが出る。修正完了

### DIFF
--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -85,7 +85,11 @@ class Projects::MessagesController < Projects::BaseProjectController
   def history
     @user = User.find(params[:user_id])
     @project = Project.find(params[:project_id])
-    @message = Message.find(params[:id])
+    @message = @project.messages
+    if @message.empty? # URL直打ち対策で定義したもの
+      flash[:alert] = "指定されたものは存在しません"
+      return redirect_to action: :index
+    end
     @messages_history = all_messages_history_month
     @messages_by_search = message_search_params.to_h
     count_recipients(@messages_history)

--- a/app/controllers/projects/messages_controller.rb
+++ b/app/controllers/projects/messages_controller.rb
@@ -87,10 +87,6 @@ class Projects::MessagesController < Projects::BaseProjectController
     @user = User.find(params[:user_id])
     @project = Project.find(params[:project_id])
     @message = @project.messages
-    if @message.empty? # URL直打ち対策で定義したもの
-      flash[:alert] = "指定されたものは存在しません"
-      return redirect_to action: :index
-    end
     @messages_history = all_messages_history_month
     @messages_by_search = message_search_params.to_h
     count_recipients(@messages_history)

--- a/app/controllers/projects/reports_controller.rb
+++ b/app/controllers/projects/reports_controller.rb
@@ -190,10 +190,6 @@ class Projects::ReportsController < Projects::BaseProjectController
   def history
     set_project_and_members
     @report = @project.reports
-    if @report.empty? # URL直打ち対策で定義したもの
-      flash[:alert] = "指定されたものは存在しません"
-      return redirect_to action: :index
-    end
     @report_history = all_reports_history_month
     @reports_by_search = report_search_params.to_h
     all_reports_history_month

--- a/app/controllers/projects/reports_controller.rb
+++ b/app/controllers/projects/reports_controller.rb
@@ -6,6 +6,7 @@ class Projects::ReportsController < Projects::BaseProjectController
 
   def index
     set_project_and_members
+    @reports_all = @project.reports
     @first_question = @project.questions.first
     @report_label_name = @first_question.send(@first_question.form_table_type).label_name
     monthly_reports

--- a/app/controllers/projects/reports_controller.rb
+++ b/app/controllers/projects/reports_controller.rb
@@ -189,7 +189,11 @@ class Projects::ReportsController < Projects::BaseProjectController
   # 報告履歴
   def history
     set_project_and_members
-    @report = Report.find(params[:id])
+    @report = @project.reports
+    if @report.empty? # URL直打ち対策で定義したもの
+      flash[:alert] = "指定されたものは存在しません"
+      return redirect_to action: :index
+    end
     @report_history = all_reports_history_month
     @reports_by_search = report_search_params.to_h
     all_reports_history_month

--- a/app/views/projects/messages/history.html.erb
+++ b/app/views/projects/messages/history.html.erb
@@ -89,7 +89,9 @@
       <% end %>
     </div>
   <% else @messages_history.blank?%>
-    <P>連絡履歴がありません。</P>
+    <div class="d-flex justify-content-end">
+      <P class="report-none">連絡履歴がありません</P>
+    </div>
   <% end %>
   <div class="d-flex">
     <% if @messages_history.present?%>

--- a/app/views/projects/messages/history.html.erb
+++ b/app/views/projects/messages/history.html.erb
@@ -12,23 +12,23 @@
   </div>
   <div class="d-flex justify-content-start mb-3">
     <% if params[:search].present? && params[:search] != "" %>
-      <%= link_to "csvエクスポート", history_user_project_message_path(format: :csv,  search: @messages_by_search ), class: "btn btn-outline-orange" %>
+      <%= link_to "csvエクスポート", history_user_project_messages_path(format: :csv,  search: @messages_by_search ), class: "btn btn-outline-orange" %>
     <% elsif params[:month].present? %>
-      <%= link_to "csvエクスポート", history_user_project_message_path(format: :csv, month: params[:month]), class: "btn btn-outline-orange" %>    
+      <%= link_to "csvエクスポート", history_user_project_messages_path(format: :csv, month: params[:month]), class: "btn btn-outline-orange" %>    
     <% else %>    
-      <%= link_to "csvエクスポート", history_user_project_message_path(format: :csv), class: "btn btn-outline-orange"  %>
+      <%= link_to "csvエクスポート", history_user_project_messages_path(format: :csv), class: "btn btn-outline-orange"  %>
     <% end %>
   </div>
   <% if @messages_history.present? %>  
     <div class="d-flex justify-content-between mb-3 rwd-search-form">
       <div class="align-self-end">
-        <%= form_with url: history_user_project_message_path(current_user, @project), method: :get, local: true do |f| %>
+        <%= form_with url: history_user_project_messages_path(current_user, @project), method: :get, local: true do |f| %>
           <%= f.month_field :month, use_month_numbers: true, discard_day: true, value: @month, class: "search-box rwd-search-box" %>
           <%= f.submit "選択した月を表示", class: "btn btn-outline-orange rwd-submit-btn" %>
         <% end %>
       </div>
       <div class="align-self-end rwd-search-block">    
-        <%= form_with scope: :search, url: history_user_project_message_path(current_user,@project), method: :get, local: true do |form| %>
+        <%= form_with scope: :search, url: history_user_project_messages_path(current_user,@project), method: :get, local: true do |form| %>
           <%= form.hidden_field :search_type, :value => "message" %>
           
           <%= form.label :created_at, "連絡受信日：", class: "mb-0" %>

--- a/app/views/projects/messages/index.html.erb
+++ b/app/views/projects/messages/index.html.erb
@@ -13,9 +13,11 @@
 <div class="card-box">  
   <p class="project-name-text">プロジェクト：<%= @project.name %></p>  
   <h1 class="text-center">連絡一覧</h1>
+  <% unless @messages.blank? %>
   <div class="d-flex justify-content-end mb-3">
-    <%= link_to "連絡履歴", history_user_project_message_path(id: @project.id, project_id: @project.id, user_id: current_user.id), class: "btn btn-outline-orange" %>
+    <%= link_to "連絡履歴", history_user_project_messages_path(user_id: current_user, project_id: @project.id), class: "btn btn-outline-orange" %>
   </div>
+  <% end %>
   <div class="card">
     <div class="card-header">
       <ul class="nav nav-tabs card-header-tabs pull-right"  id="myTab" role="tablist">

--- a/app/views/projects/reports/_all_reports.html.erb
+++ b/app/views/projects/reports/_all_reports.html.erb
@@ -97,9 +97,7 @@
       <% end %>
     </div>
   <% else @all_reports.blank?%>
-    <div class="d-flex justify-content-end">
-      <P class="report-none">全メンバーの報告履歴がありません</P>
-    </div>
+      <P>全メンバーの報告履歴がありません。</P>
   <% end %>
   <div class="d-flex">
     <% if @all_reports.present?%>

--- a/app/views/projects/reports/_reports.html.erb
+++ b/app/views/projects/reports/_reports.html.erb
@@ -91,9 +91,7 @@
       <% end %>
     </div>
   <% else @reports.blank?%>
-    <div class="d-flex justify-content-end">
-      <P class="report-none">他メンバーの報告履歴がありません</P>
-    </div>
+      <P>他メンバーの報告履歴がありません。</P>
   <% end %>
   <div class="d-flex">
     <% if @reports.present?%>

--- a/app/views/projects/reports/_you_reports.html.erb
+++ b/app/views/projects/reports/_you_reports.html.erb
@@ -98,9 +98,7 @@
       <% end %>
     </div>
   <% else @you_reports.blank?%>
-    <div class="d-flex justify-content-end">
-      <p class="report-none">あなたの報告履歴がありません。</p>
-    </div>
+      <p>あなたの報告履歴がありません。</p>
   <% end %>
   <div class="d-flex">
     <% if @you_reports.present?%>

--- a/app/views/projects/reports/history.html.erb
+++ b/app/views/projects/reports/history.html.erb
@@ -11,23 +11,23 @@
   </div>
   <div class="d-flex justify-content-start mb-3">
     <% if params[:search].present? && params[:search] != "" %>
-      <%= link_to "csvエクスポート", history_user_project_report_path(format: :csv, search: @reports_by_search), class: "btn btn-outline-orange" %>
+      <%= link_to "csvエクスポート", history_user_project_reports_path(format: :csv, search: @reports_by_search), class: "btn btn-outline-orange" %>
     <% elsif params[:month].present? %>
-      <%= link_to "csvエクスポート", history_user_project_report_path(format: :csv, month: params[:month]), class: "btn btn-outline-orange" %>
+      <%= link_to "csvエクスポート", history_user_project_reports_path(format: :csv, month: params[:month]), class: "btn btn-outline-orange" %>
     <% else %>
-      <%= link_to "csvエクスポート", history_user_project_report_path(format: :csv), class: "btn btn-outline-orange" %>
+      <%= link_to "csvエクスポート", history_user_project_reports_path(format: :csv), class: "btn btn-outline-orange" %>
     <% end %>
   </div>
   <% if @report_history.present? %>
     <div class="d-flex justify-content-between mb-3">
       <div class="align-self-end">
-        <%= form_with url: history_user_project_report_path(current_user, @project), method: :get, local: true do |f| %>
+        <%= form_with url: history_user_project_reports_path(current_user, @project), method: :get, local: true do |f| %>
           <%= f.month_field :month, use_month_numbers: true, discard_day: true, value: @month, class: "search-box" %>
           <%= f.submit "選択した月を表示", class: "btn btn-outline-orange" %>
         <% end %>
       </div>
       <div class="align-self-end">
-        <%= form_with scope: :search, url: history_user_project_report_path(current_user,@project), method: :get, local: true do |form| %>
+        <%= form_with scope: :search, url: history_user_project_reports_path(current_user,@project), method: :get, local: true do |form| %>
           <%= form.hidden_field :search_type, value: "all-report" %>
           
           <%= form.label :created_at, "報告日：", class: "mb-0" %>

--- a/app/views/projects/reports/index.html.erb
+++ b/app/views/projects/reports/index.html.erb
@@ -12,7 +12,7 @@
 <div class="card-box">
   <p class="project-name-text">プロジェクト：<%= @project.name %></p>
   <h1 class="text-center">報告一覧</h1>
-  <% unless @reports.blank? %>
+  <% unless @reports_all.blank? %>
   <div class="d-flex justify-content-end mb-3">
     <%= link_to "報告履歴", history_user_project_reports_path(user_id: current_user.id, project_id: @project.id), class: "btn btn-outline-orange" %>
   </div>

--- a/app/views/projects/reports/index.html.erb
+++ b/app/views/projects/reports/index.html.erb
@@ -12,9 +12,11 @@
 <div class="card-box">
   <p class="project-name-text">プロジェクト：<%= @project.name %></p>
   <h1 class="text-center">報告一覧</h1>
+  <% unless @reports.blank? %>
   <div class="d-flex justify-content-end mb-3">
-    <%= link_to "報告履歴", history_user_project_report_path(id: @project.id, project_id: @project.id, user_id: current_user.id), class: "btn btn-outline-orange" %>
+    <%= link_to "報告履歴", history_user_project_reports_path(user_id: current_user.id, project_id: @project.id), class: "btn btn-outline-orange" %>
   </div>
+  <% end %>
   <div class="card">
     <div class="card-header">
       <ul class="nav nav-tabs card-header-tabs pull-right"  id="myTab" role="tablist">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,8 @@ Rails.application.routes.draw do
           member do
             post 'reject'
             post 'resubmitted'
+          end
+          collection do
             get 'history'
           end
           resources :report_replys, only: %i[edit  create update destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,8 @@ Rails.application.routes.draw do
         resources :messages do
           member do
             patch 'read'
+          end
+          collection do
             get 'history'
           end
           resources :message_replys, only: %i[edit create update destroy] do


### PR DESCRIPTION
### 概要
問題表36：報告・連絡の投稿が0件の場合に履歴ページへのボタンを押すとエラーが出る。
について連絡部分の修正が完了しました。
報告部分については、こちら承認いただいてから対応いたします。
　→　報告部分も修正完了したため、コミット追加しました。

### タスク
- [ ] なし
- [x] あり https://docs.google.com/spreadsheets/d/13gLhBRmXqtZu4EBsfG-Jq9vD32EhqQzGTKOQlgkpb4U/edit?usp=sharing

### 実装内容・手法
routes memberをcollectionへ変更。連絡データ全て取得するようhistoryﾒｿｯﾄﾞで定義し、データある場合のみ「履歴」ボタンが表示されるよう変更。※URL直打ち対策済
→　URL直打ち制限について記述削除しました。履歴データが無い場合の表示が既に準備されていたため、そちらを表示するため制限記述削除しました。

### gemfileの変更
- [x] なし
- [ ] あり 
