### PR TITLE
本番環境へのRedis + Sidekiq追加 / Sidekiqダッシュボードのアクセス制限

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -7,6 +7,7 @@ RUN apt-get update \
     postgresql-client \
     nodejs \
     vim \
+    redis-tools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,7 +117,12 @@ Rails.application.routes.draw do
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
 
-  # Sidekiqダッシュボードをマウント
-  mount Sidekiq::Web => '/sidekiq'
+  # 管理者ユーザーのみ、Sidekiqダッシュボードにアクセス可能とする
+  authenticate :user, lambda { |u| u.admin? } do
+    # Sidekiqダッシュボードをマウント
+    mount Sidekiq::Web => '/sidekiq'
+  end
+  # 管理者以外がSidekiqダッシュボードにアクセスした場合は、rootへリダイレクトする
+  get '/sidekiq', to: redirect('/')
 
 end

--- a/docker-compose.heroku.yml
+++ b/docker-compose.heroku.yml
@@ -20,8 +20,10 @@ services:
     depends_on:
       - db
       - chrome
+      - redis
     environment:
       SELENIUM_REMOTE_URL: http://chrome:4444/wd/hub
+      REDIS_URL: redis://redis:6379/0
     # (stdin_open,tty) = コンテナ内でデバックできるようにする
     stdin_open: true
     tty: true
@@ -41,5 +43,26 @@ services:
     image: selenium/standalone-chrome:latest
     ports:
       - 4444:4444
+  sidekiq:
+    build: .
+    command: bundle exec sidekiq -C config/sidekiq.yml
+    volumes:
+      - .:/myproject
+    depends_on:
+      - db
+      - redis
+    environment:
+      REDIS_URL: redis://redis:6379/0
+  redis:
+    # (image: redis) = db:と環境を統一して常に最新バージョンを使用
+    # (image: redis:6.2) = db:と統一ぜず安定バージョンに固定する際はこの記述へ要変更
+    image: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    # (restart: always) = コンテナ停止時に自動で再起動するためのオプション
+    restart: always
 volumes:
   postgres-data:
+  redis-data:


### PR DESCRIPTION
### 概要
1. 本番環境へのRedis + Sidekiq追加
2. Sidekiqダッシュボードのアクセス制限

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
1. 本番環境へのRedis + Sidekiq追加
⇨ herokuデプロイ用のDockerfile, docker-compose.ymlを修正し、Redis + Sidekiq環境を適用。

　◼️ 本番環境(heroku)URL
　https://horenso-app-e035c5c06090.herokuapp.com/
　⇨ Redis + Sidekiq環境を適用済。

2. Sidekiqダッシュボードのアクセス制限
⇨ Sidekiqのダッシュボードは、管理者ユーザーでログインしている場合のみアクセス可能とし、その他の場合はrootへリダイレクトする。

### 関連資料
_([herokuデプロイ手順](https://docs.google.com/spreadsheets/d/1IOQsPmCm3fIcroKeHTUXbSyYrfOe0oZT-dy130eUjic/edit?gid=204828406#gid=204828406&range=A1))_
⇨ herokuにRedisデータベースを作成する手順を追加。

_([ジョブスケジューラーの確認方法](https://docs.google.com/spreadsheets/d/1IOQsPmCm3fIcroKeHTUXbSyYrfOe0oZT-dy130eUjic/edit?gid=2122568451#gid=2122568451&range=A1))_
⇨ Sidekiqダッシュボードは、管理者ユーザーのみがアクセス可能である旨を追記。

### gemfileの変更
- [x] なし
- [ ] あり 
