### PR TITLE
問題表38：連絡作成・相談編集完了後、ヘッダー及び画面上部に同じメッセージが表示される　修正完了

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :store_user_location!, if: :storable_location?
+  before_action :reset_flash_message_displayed
 
   def store_user_location!
     store_location_for(:user, request.fullpath)
@@ -26,5 +27,11 @@ class ApplicationController < ActionController::Base
   def extract_counseling_id_from_path(path)
     match = path.match(/counselings\/(\d+)/)
     match[1] if match
+  end
+
+  private
+
+  def reset_flash_message_displayed
+    session[:flash_message_displayed] = false # ﾌﾗｯｼｭﾒｯｾｰｼﾞをﾘｾｯﾄ
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,6 +49,14 @@ module ApplicationHelper
   # テキスト内のURLを自動的にリンクに変換する。また、改行を有効化する。
   def format_text(text)
     link_text = Rinku.auto_link(simple_format(text), :urls, 'target="_blank" rel="noopener noreferrer"')
-    sanitize(link_text, tags: %w(a p br), attributes: %w(href target rel))        # サニタイズして必要なタグと属性を許可
+    sanitize(link_text, tags: %w(a p br), attributes: %w(href target rel)) # サニタイズして必要なタグと属性を許可
+  end
+
+  def flash_message_displayed!
+    session[:flash_message_displayed] = true # flash_messageが表示されている場合trueになる
+  end
+
+  def flash_message_displayed?
+    session[:flash_message_displayed] # true or falseを保持しているが初期は定義していないためfalse
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,10 +1,13 @@
 <nav class="navbar navbar-expand-lg navbar-light header shadow bg-white rounded justify-content-center">
   <%= link_to "Horenso_App", root_path, class: "h1 mb-1" %>
-  <% flash.each do |key, value| %>
-    <% if key != :search_error %>
-      <%= content_tag(:a, value, class: "alert alert-#{bootstrap_alert(key)} mb-0 ml-3") %>
+    <% unless flash_message_displayed? %>
+      <% flash.each do |key, value| %>
+        <% if key != :search_error %>
+          <%= content_tag(:a, value, class: "alert alert-#{bootstrap_alert(key)} mb-0 ml-3") %>
+        <% end %>
+      <% end %>
+      <% flash_message_displayed! %>
     <% end %>
-  <% end %>
   <% if user_signed_in? %>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>

--- a/app/views/projects/counselings/index.html.erb
+++ b/app/views/projects/counselings/index.html.erb
@@ -5,8 +5,11 @@
 <% end %>
 
 <div id="flash-messages">
-  <% flash.each do |key, message| %>
-    <div class="alert alert-<%= key %>"><%= message %></div>
+  <% unless flash_message_displayed? %>
+    <% flash.each do |key, message| %>
+      <div class="alert alert-<%= key %>"><%= message %></div>
+    <% end %>
+    <% flash_message_displayed! %>
   <% end %>
 </div>
 

--- a/app/views/projects/messages/index.html.erb
+++ b/app/views/projects/messages/index.html.erb
@@ -5,8 +5,11 @@
 <% end %>
 
 <div id="flash-messages">
-  <% flash.each do |key, message| %>
-    <div class="alert alert-<%= key %>"><%= message %></div>
+  <% unless flash_message_displayed? %>
+    <% flash.each do |key, message| %>
+      <div class="alert alert-<%= key %>"><%= message %></div>
+    <% end %>
+    <% flash_message_displayed! %>
   <% end %>
 </div>
 

--- a/app/views/projects/reports/index.html.erb
+++ b/app/views/projects/reports/index.html.erb
@@ -4,8 +4,11 @@
 <% end %>
 
 <div id="flash-messages">
-  <% flash.each do |key, message| %>
-    <div class="alert alert-<%= key %>"><%= message %></div>
+  <% unless flash_message_displayed? %>
+    <% flash.each do |key, message| %>
+      <div class="alert alert-<%= key %>"><%= message %></div>
+    <% end %>
+    <% flash_message_displayed! %>
   <% end %>
 </div>
 


### PR DESCRIPTION
### 概要
問題表38：連絡作成・相談編集完了後、ヘッダー及び画面上部に同じメッセージが表示される　修正完了

### タスク
- [ ] なし
- [x] あり https://docs.google.com/spreadsheets/d/13gLhBRmXqtZu4EBsfG-Jq9vD32EhqQzGTKOQlgkpb4U/edit?usp=sharing

### 実装内容・手法
　MTGの際、室伏さんからいただいたアドバイスを参考に片方のメッセージが表示されている場合、もう片方のメッセージは表示されないように条件を設け実装しました。
　_header.html → index.html　という順番で処理されるはずなのでヘッダーのメッセージが優先されると思っていましたが、結果はindexが優先され少し納得できない部分がありますが・・・

### gemfileの変更
- [x] なし
- [ ] あり 
