### PR TITLE
相談履歴ページ追加

### DIFF
--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -348,5 +348,4 @@ class Projects::CounselingsController < Projects::BaseProjectController
     end
     send_data(csv_data, filename: "相談履歴.csv")
   end
-
 end

--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -306,7 +306,7 @@ class Projects::CounselingsController < Projects::BaseProjectController
       @results = Counseling.search(counseling_search_params)
       if @results.present?
         @counseling_ids = @results.pluck(:id).uniq || @results.pluck(:counseling_id).uniq
-        @counseling_history = 11
+        @counseling_history = all_counselings_history.where(id: @counseling_ids)
       else
         flash.now[:danger] = '検索結果が見つかりませんでした。' if @results.blank?
       end

--- a/app/models/counseling.rb
+++ b/app/models/counseling.rb
@@ -32,12 +32,24 @@ class Counseling < ApplicationRecord
   # 検索機能
   def self.search(search_params)
     query = all
-    if search_params[:keywords].present?
-      keyword = "%#{search_params[:keywords]}%"
-      query = query.where("title LIKE :keyword OR counseling_detail LIKE :keyword", keyword: keyword)
+
+    if search_params[:created_at].present?
+      query = query.created_at(search_params[:created_at])
     end
+
+    if search_params[:keywords].present?
+      query = query.keywords_like(search_params[:keywords])
+    end
+    
     query
   end
+
+  scope :created_at, ->(created_at) {
+    where("created_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo' BETWEEN ? AND ?", "#{created_at} 00:00:00", "#{created_at} 23:59:59")
+  }
+  scope :keywords_like, ->(keywords) {
+    where('title LIKE :keyword OR sender_name LIKE :keyword OR counseling_detail LIKE :keyword', keyword: "%#{keywords}%")
+  }
 
   def send_to_all?
     ActiveRecord::Type::Boolean.new.cast(send_to_all)

--- a/app/models/counseling.rb
+++ b/app/models/counseling.rb
@@ -40,7 +40,7 @@ class Counseling < ApplicationRecord
     if search_params[:keywords].present?
       query = query.keywords_like(search_params[:keywords])
     end
-    
+
     query
   end
 

--- a/app/views/projects/counselings/_all_counselings.html.erb
+++ b/app/views/projects/counselings/_all_counselings.html.erb
@@ -14,7 +14,7 @@
         件名
       </div>
       <div class="counseling-date">
-        連絡日
+        相談日
       </div>
       <div class="counseling-person">
         相談者

--- a/app/views/projects/counselings/_you_addressee_counselings.html.erb
+++ b/app/views/projects/counselings/_you_addressee_counselings.html.erb
@@ -14,7 +14,7 @@
         件名
       </div>
       <div class="counseling-date">
-        連絡日
+        相談日
       </div>
       <div class="counseling-person">
         相談者

--- a/app/views/projects/counselings/history.html.erb
+++ b/app/views/projects/counselings/history.html.erb
@@ -70,7 +70,7 @@
     </div>
   <% else @counseling_history.blank?%>
     <div class="d-flex justify-content-end">
-      <P class="counseling-none">相談履歴がありません</P>
+      <P class="report-none">相談履歴がありません</P>
     </div>
   <% end %>
   <div class="d-flex">

--- a/app/views/projects/counselings/history.html.erb
+++ b/app/views/projects/counselings/history.html.erb
@@ -1,0 +1,86 @@
+<% provide(:title, '相談履歴') %>
+<%= content_for :side_menu do %>
+  <%= render partial: 'layouts/sidebar' , locals: { user: @user, project: @project } %>
+<% end %>
+
+<div class="card-box">
+  <p class="project-name-text">プロジェクト：<%= @project.name %></p>  
+  <h1 class="text-center">相談履歴</h1>
+  <div class="d-flex justify-content-end mb-3">
+    <%= link_to "相談一覧", user_project_counselings_path, class: "btn btn-outline-orange" %>
+  </div>
+  <div class="d-flex justify-content-start mb-3">
+    <% if params[:search].present? && params[:search] != "" %>
+      <%= link_to "csvエクスポート", history_user_project_counselings_path(format: :csv, search: @counselings_by_search), class: "btn btn-outline-orange" %>
+    <% elsif params[:month].present? %>
+      <%= link_to "csvエクスポート", history_user_project_counselings_path(format: :csv, month: params[:month]), class: "btn btn-outline-orange" %>
+    <% else %>
+      <%= link_to "csvエクスポート", history_user_project_counselings_path(format: :csv), class: "btn btn-outline-orange" %>
+    <% end %>
+  </div>
+  <% if @counseling_history.present? %>
+    <div class="d-flex justify-content-between mb-3">
+      <div class="align-self-end">
+        <%= form_with url: history_user_project_counselings_path(current_user, @project), method: :get, local: true do |f| %>
+          <%= f.month_field :month, use_month_numbers: true, discard_day: true, value: @month, class: "search-box" %>
+          <%= f.submit "選択した月を表示", class: "btn btn-outline-orange" %>
+        <% end %>
+      </div>
+      <div class="align-self-end">
+        <%= form_with scope: :search, url: history_user_project_counselings_path(current_user,@project), method: :get, local: true do |form| %>
+          <%= form.hidden_field :search_type, value: "counseling" %>
+          
+          <%= form.label :created_at, "相談日：", class: "mb-0" %>
+          <%= form.date_field :created_at, placeholder: "相談日を入力", value: @search_params && @search_params[:created_at], class: "search-box" %>
+          
+          <%= form.label :keywords, "キーワード：", class: "mb-0" %>
+          <%= form.text_field :keywords, placeholder: "キーワードを入力", value: @search_params && @search_params[:keywords], class: "search-box" %>
+          
+          <%= form.submit "検索", class: "btn btn-outline-orange" %>            
+        <% end %>
+      </div>
+    </div>
+    <div class="table-header">
+      <div class="subject-name col-md-4">
+        <%=@project.format.title%>
+      </div>
+      <div class="counseling-date col-md-4">
+        相談日
+      </div>
+      <div class="counseling-person col-md-4">
+        相談者
+      </div>
+    </div>
+    <div class="table-body">
+      <% line_num = 0%>
+      <% @counseling_history.each do |counseling|%>
+        <% line_num += 1%>
+        <div class="table-line", data-project-index-line-num="<%="#{line_num}"%>" id="you_counseling_<%= counseling.id %>">    
+          <div class="subject-name col-md-4">
+            <%= link_to counseling.title, user_project_counseling_path(@user, @project, counseling), class: "counseling-detail-link" %>
+          </div>
+          <div class="counseling-date col-md-4">
+            <%= l(counseling.created_at, format: :long) %>
+          </div>
+          <div class="counseling-person col-md-4">
+            <%= counseling.sender_name %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else @counseling_history.blank?%>
+    <div class="d-flex justify-content-end">
+      <P class="counseling-none">相談履歴がありません</P>
+    </div>
+  <% end %>
+  <div class="d-flex">
+    <% if @counseling_history.present?%>
+      <div class="paginate">
+        <%= paginate @counseling_history %>
+      </div>
+    <% end %>
+    <div class="ml-auto">
+      <%= link_to "戻る", :back, class: "btn btn-secondary" %>
+    </div>
+  </div>
+</div>

--- a/app/views/projects/counselings/index.html.erb
+++ b/app/views/projects/counselings/index.html.erb
@@ -23,6 +23,11 @@
   </div -->
   <p class="project-name-text">プロジェクト：<%= @project.name %></p>
   <h1 class="text-center">相談一覧</h1>
+  <% unless @counselings.blank? %>
+    <div class="d-flex justify-content-end mb-3">
+      <%= link_to "相談履歴", history_user_project_counselings_path(user_id: current_user.id, project_id: @project.id), class: "btn btn-outline-orange" %>
+    </div>
+  <% end %>
   <div class="card">
     <div class="card-header">
       <ul class="nav nav-tabs card-header-tabs pull-right"  id="myTab" role="tablist">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
           end
           collection do
             get 'export_csv'
+            get 'history'
           end
           resources :counseling_replys, only: %i[edit  create update destroy] do
             member do


### PR DESCRIPTION
### 概要
① 相談履歴ページの追加
② 相談履歴のCSV出力
③ 相談一覧ページの文言修正

### タスク
- [ ] なし
- [x] あり _[詳細設計259・260](https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit?gid=1075510033#gid=1075510033&range=A256)_
 

### 実装内容・手法
① 報告・連絡と同等の相談履歴ページ追加。
② 相談履歴ページに表示された相談内容のCSVエクスポート機能追加。
⇨ 同ページの機能は画面設計書を参照。

③ 相談一覧ページのテーブルのヘッダの文言変更
　「連絡日」➡︎「相談日」に修正。

### 実装画像などあれば添付する
_[画面設計書：相談履歴](https://docs.google.com/spreadsheets/d/1zZuioWUIBcg-FuWLLUdkpbVa4anMRSBjtn2VGlLcIsM/edit?gid=1662588314#gid=1662588314&range=A1)_

### gemfileの変更
- [x] なし
- [ ] あり 
