### PR TITLE
問題表41：報告したあとフォーマット編集で有効にするチェックボックスをオフにした後、報告編集ボタンを押下するとエラーになる場合がある　修正完了

### DIFF
--- a/app/controllers/projects/reports_controller.rb
+++ b/app/controllers/projects/reports_controller.rb
@@ -55,7 +55,8 @@ class Projects::ReportsController < Projects::BaseProjectController
     @report = Report.includes(:answers).find(params[:id])
     @user = User.find(@report.user_id)
     @questions = @project.questions.where(using_flag: true).order(:id)
-    @answers = @report.answers.order(:id)
+    # 有効な質問に関連する回答のみ取得
+    @answers = @report.answers.joins(:question).where(questions: { id: @questions.map(&:id) }).order(:id)
   end
 
   # rubocopを一時的に無効にする。

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,5 +1,5 @@
 class Answer < ApplicationRecord
   belongs_to :report
-
+  belongs_to :question
   # validates :array_value, acceptance: true
 end

--- a/app/views/projects/reports/_edit_check_box.html.erb
+++ b/app/views/projects/reports/_edit_check_box.html.erb
@@ -1,5 +1,4 @@
 <div class="report-form">
-  <% Rails.logger.debug "Check Box - Question ID: #{question&.id}, Using Flag: #{question&.using_flag}, Answer Question ID: #{answer&.question_id}" %>
   <% if question.present? && question.using_flag && question.check_box.present? %>
     <!-- check_boxが存在し、かつ有効な場合の処理 -->
     <span class="report-item-title mb-2 font-weight-bold"><%= question.check_box.label_name %></span>

--- a/app/views/projects/reports/_edit_check_box.html.erb
+++ b/app/views/projects/reports/_edit_check_box.html.erb
@@ -1,6 +1,7 @@
 <div class="report-form">
-  <% if question.present? && question.check_box.present? %>
-    <!-- check_boxが存在する場合の処理 -->
+  <% Rails.logger.debug "Check Box - Question ID: #{question&.id}, Using Flag: #{question&.using_flag}, Answer Question ID: #{answer&.question_id}" %>
+  <% if question.present? && question.using_flag && question.check_box.present? %>
+    <!-- check_boxが存在し、かつ有効な場合の処理 -->
     <span class="report-item-title mb-2 font-weight-bold"><%= question.check_box.label_name %></span>
     <% if question.required %><span class="pl-2 font-weight-bold text-danger">必須</span><% end %>
     <br>
@@ -17,20 +18,6 @@
       <% end %>
     <% end %>
   <% else %>
-    <!-- check_boxが存在しない場合（削除された質問など）の処理 -->
-    <span class="report-item-title mb-2 font-weight-bold"><%= answer.question_name %></span>
-    <span class="pl-2 font-weight-bold text-danger">※削除された質問です。この項目は削除されます。</span>
-    <br>
-    <% if answer.array_value.count != 0 %>
-      <% answer.array_value.each do |buf| %>
-        <div class="card-text ml-0 test">
-          <%= buf %>
-        </div>
-      <% end %>
-    <% else %>
-      <div class="card-text ml-0">
-        回答なし
-      </div>
-    <% end %>
+     <!-- questionまたはcheck_boxが存在しない場合や無効の場合は表示しない -->
   <% end %>
 </div>

--- a/app/views/projects/reports/_edit_check_box.html.erb
+++ b/app/views/projects/reports/_edit_check_box.html.erb
@@ -1,21 +1,7 @@
 <div class="report-form">
-  <% check_box = question.check_box %>
-  <% if check_box.nil? %>
-    <span class="report-item-title mb-2 font-weight-bold"><%= answer.question_name %></span><span class="pl-2 font-weight-bold text-danger">※削除された質問です。この項目は削除されます。</span>
-    <br>
-    <% if answer.array_value.count != 0 %>
-      <% answer.array_value.each do |buf| %>
-        <div class="card-text ml-0 test">
-          <%= buf %>
-        </div>
-      <% end %>
-    <% else %>
-      <div class="card-text ml-0">
-        回答なし
-      </div>
-    <% end %>
-  <% else %>
-    <span class="report-item-title mb-2 font-weight-bold"><%= check_box.label_name %></span>
+  <% if question.present? && question.check_box.present? %>
+    <!-- check_boxが存在する場合の処理 -->
+    <span class="report-item-title mb-2 font-weight-bold"><%= question.check_box.label_name %></span>
     <% if question.required %><span class="pl-2 font-weight-bold text-danger">必須</span><% end %>
     <br>
     <%= f.fields_for :answers, answer do |m| %>
@@ -28,7 +14,23 @@
                       %>
         <%= m.check_box :array_value, {multiple: true, include_hidden: false, checked: boolExists, required: question.required}, box[:option_string] %>
         <%= box.option_string %>
-      <% end %> 
-    <% end %> 
+      <% end %>
+    <% end %>
+  <% else %>
+    <!-- check_boxが存在しない場合（削除された質問など）の処理 -->
+    <span class="report-item-title mb-2 font-weight-bold"><%= answer.question_name %></span>
+    <span class="pl-2 font-weight-bold text-danger">※削除された質問です。この項目は削除されます。</span>
+    <br>
+    <% if answer.array_value.count != 0 %>
+      <% answer.array_value.each do |buf| %>
+        <div class="card-text ml-0 test">
+          <%= buf %>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="card-text ml-0">
+        回答なし
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/projects/reports/_edit_date_field.html.erb
+++ b/app/views/projects/reports/_edit_date_field.html.erb
@@ -1,23 +1,13 @@
 <div class="report-form">
-  <% date_field = question.date_field %>
-  <% if date_field.nil?%>
-    <span class="report-item-title mb-2 font-weight-bold"><%= answer.question_name %></span><span class="pl-2 font-weight-bold text-danger">※削除された質問です。この項目は削除されます。</span>
-    <br>
-    <% if !answer.value.blank? %>
-      <div class="card-text ml-0">
-        <%= format_text(answer.value) %>
-      </div>
-    <% else %>
-      <div class="card-text ml-0">
-        回答なし
-      </div>
-    <% end %>
-  <% else %>
-    <span class="report-item-title mb-2 font-weight-bold"><%= date_field.label_name %></span>
+  <% if question.present? && question.using_flag && question.date_field.present? %>
+    <!-- date_fieldが存在し、かつ有効な場合の処理 -->
+    <span class="report-item-title mb-2 font-weight-bold"><%= question.date_field.label_name %></span>
     <% if question.required %><span class="pl-2 font-weight-bold text-danger">必須</span><% end %>
     <%= f.fields_for :answers, answer do |m| %>
       <% defalutDate = answer.value %>
       <div><%= m.date_field :value, value: defalutDate, class: "form-control", required: question.required %></div>
     <% end %>
+  <% else %>
+     <!-- questionまたはdate_fieldが存在しない場合や無効の場合は表示しない -->
   <% end %>
 </div>

--- a/app/views/projects/reports/_edit_radio_button.html.erb
+++ b/app/views/projects/reports/_edit_radio_button.html.erb
@@ -1,25 +1,15 @@
 <div class="report-form">
-  <% if RadioButton.find_by(question_id: answer.question_id).nil?%>
-    <span class="report-item-title mb-2 font-weight-bold"><%= answer.question_name %></span><span class="pl-2 font-weight-bold text-danger">※削除された質問です。この項目は削除されます。</span>
-    <br>
-    <% if !answer.value.blank? %>
-      <div class="card-text ml-0">
-        <%= format_text(answer.value) %>
-      </div>
-    <% else %>
-      <div class="card-text ml-0">
-        回答なし
-      </div>
-    <% end %>
-  <% else %>
-    <% radio_button = question.radio_button %>
-    <span class="report-item-title mb-2 font-weight-bold"><%= radio_button.label_name %></span>
-    <span class="pl-2 font-weight-bold text-danger">必須</span>
+  <% if question.present? && question.using_flag && question.radio_button.present? %>
+    <!-- radio_buttonが存在し、かつ有効な場合の処理 -->
+    <span class="report-item-title mb-2 font-weight-bold"><%= question.radio_button.label_name %></span>
+    <% if question.required %><span class="pl-2 font-weight-bold text-danger">必須</span><% end %>
     <br>
     <%= f.fields_for :answers, answer do |m| %>
-      <%= m.collection_radio_buttons(:value, radio_button.radio_button_option_strings, :option_string , :option_string, {}, { required: true }) do |r| %>
+      <%= m.collection_radio_buttons(:value, question.radio_button.radio_button_option_strings, :option_string, :option_string, {}, { required: question.required }) do |r| %>
         <% r.label(class: "radio-label") { r.radio_button(class: "radio-button") + r.text } %>
       <% end %>
     <% end %>
+  <% else %>
+    <!-- questionまたはradio_buttonが存在しない場合や無効の場合は表示しない -->
   <% end %>
 </div>

--- a/app/views/projects/reports/_edit_select.html.erb
+++ b/app/views/projects/reports/_edit_select.html.erb
@@ -1,9 +1,18 @@
 <div class="report-form">
-  <% select = question.select %>
-  <% if select.nil?%>
-    <span class="report-item-title mb-2 font-weight-bold"><%= answer.question_name %></span><span class="pl-2 font-weight-bold text-danger">※削除された質問です。この項目は削除されます。</span>
+  <% if question.present? && question.select.present? %>
+    <!-- selectが存在する場合 -->
+    <span class="report-item-title mb-2 font-weight-bold"><%= question.select.label_name %></span>
+    <% if question.required %><span class="pl-2 font-weight-bold text-danger">必須</span><% end %>
     <br>
-    <% if !answer.value.blank? %>
+    <%= f.fields_for :answers, answer do |m| %>
+      <%= m.collection_select(:value, question.select.select_option_strings.all, :option_string, :option_string, { prompt: false }, { class: "form-control", required: question.required }) %>
+    <% end %>
+  <% else %>
+    <!-- selectが存在しない場合（削除された質問など） -->
+    <span class="report-item-title mb-2 font-weight-bold"><%= answer.question_name %></span>
+    <span class="pl-2 font-weight-bold text-danger">※削除された質問です。この項目は削除されます。</span>
+    <br>
+    <% if answer.value.present? %>
       <div class="card-text ml-0">
         <%= format_text(answer.value) %>
       </div>
@@ -11,13 +20,6 @@
       <div class="card-text ml-0">
         回答なし
       </div>
-    <% end %>
-  <% else %>
-    <span class="report-item-title mb-2 font-weight-bold"><%= select.label_name %></span>
-    <% if question.required %><span class="pl-2 font-weight-bold text-danger">必須</span><% end %>
-    <br>
-    <%= f.fields_for :answers, answer do |m| %>
-      <%= m.collection_select(:value, select.select_option_strings.all, :option_string, :option_string, { prompt: false } ,{class: "form-control", required: question.required }) %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/projects/reports/_edit_select.html.erb
+++ b/app/views/projects/reports/_edit_select.html.erb
@@ -1,6 +1,7 @@
 <div class="report-form">
-  <% if question.present? && question.select.present? %>
-    <!-- selectが存在する場合 -->
+  <% Rails.logger.debug "Select Box - Question ID: #{question&.id}, Using Flag: #{question&.using_flag}, Answer Question ID: #{answer&.question_id}" %>
+  <% if question.present? && question.using_flag && question.select.present? %>
+    <!-- selectが存在し、かつ有効な場合の処理 -->
     <span class="report-item-title mb-2 font-weight-bold"><%= question.select.label_name %></span>
     <% if question.required %><span class="pl-2 font-weight-bold text-danger">必須</span><% end %>
     <br>
@@ -8,18 +9,6 @@
       <%= m.collection_select(:value, question.select.select_option_strings.all, :option_string, :option_string, { prompt: false }, { class: "form-control", required: question.required }) %>
     <% end %>
   <% else %>
-    <!-- selectが存在しない場合（削除された質問など） -->
-    <span class="report-item-title mb-2 font-weight-bold"><%= answer.question_name %></span>
-    <span class="pl-2 font-weight-bold text-danger">※削除された質問です。この項目は削除されます。</span>
-    <br>
-    <% if answer.value.present? %>
-      <div class="card-text ml-0">
-        <%= format_text(answer.value) %>
-      </div>
-    <% else %>
-      <div class="card-text ml-0">
-        回答なし
-      </div>
-    <% end %>
+    <!-- questionまたはselectが存在しない場合や無効な場合は表示しない -->
   <% end %>
 </div>

--- a/app/views/projects/reports/_edit_text_area.html.erb
+++ b/app/views/projects/reports/_edit_text_area.html.erb
@@ -1,21 +1,14 @@
 <div class="report-form">
-  <% if TextArea.find_by(question_id: answer.question_id).nil?%>
-    <span class="report-item-title mb-2 font-weight-bold"><%= answer.question_name %></span><span class="pl-2 font-weight-bold text-danger">※削除された質問です。この項目は削除されます。</span>
-    <br>
-    <% if !answer.value.blank? %>
-      <div class="card-text ml-0">
-        <%= format_text(answer.value) %>
-      </div>
-    <% else %>
-      <div class="card-text ml-0">
-        回答なし
-      </div>
-    <% end %>
-  <% else %>
+  <% if question.present? && question.using_flag && question.text_area.present? %>
+    <!-- text_areaが存在し、かつ有効な場合の処理 -->
     <span class="report-item-title mb-2 font-weight-bold"><%= question.text_area.label_name %></span>
     <% if question.required %><span class="pl-2 font-weight-bold text-danger">必須</span><% end %>
     <%= f.fields_for :answers, answer do |m| %>
-      <div><%= m.text_area :value, class: "form-control",required: question.required %></div>
+      <div>
+        <%= m.text_area :value, class: "form-control", required: question.required %>
+      </div>
     <% end %>
+  <% else %>
+    <!-- questionまたはtext_areaが存在しない場合や無効な場合は表示しない -->
   <% end %>
 </div>

--- a/app/views/projects/reports/_edit_text_field.html.erb
+++ b/app/views/projects/reports/_edit_text_field.html.erb
@@ -1,22 +1,12 @@
 <div class="report-form">
-  <% text_field = question.text_field %>
-  <% if text_field.nil?%>
-    <span class="report-item-title mb-2 font-weight-bold"><%= answer.question_name %></span><span class="pl-2 font-weight-bold text-danger">※削除された質問です。この項目は削除されます。</span>
-    <br>
-    <% if !answer.value.blank? %>
-      <div class="card-text ml-0">
-        <%= format_text(answer.value) %>
-      </div>
-    <% else %>
-      <div class="card-text ml-0">
-        回答なし
-      </div>
-    <% end %>
-  <% else %>
-    <span class="report-item-title mb-2 font-weight-bold"><%= text_field.label_name %></span>
+  <% if question.present? && question.using_flag && question.text_field.present? %>
+    <!-- text_fieldが存在し、かつ有効な場合の処理 -->
+    <span class="report-item-title mb-2 font-weight-bold"><%= question.text_field.label_name %></span>
     <% if question.required %><span class="pl-2 font-weight-bold text-danger">必須</span><% end %>
-      <%= f.fields_for :answers, answer do |m| %>
+    <%= f.fields_for :answers, answer do |m| %>
       <div><%= m.text_field :value, class: "form-control", required: question.required %></div>
     <% end %>
+  <% else %>
+    <!-- questionまたはtext_fieldが存在しない場合や無効な場合は表示しない -->
   <% end %>
 </div>


### PR DESCRIPTION
### 概要
　問題表41：報告したあとフォーマット編集で有効にするチェックボックスをオフにした後、報告編集ボタンを押下するとエラーになる場合がある　修正完了

### タスク
- [ ] なし
- [x] あり https://docs.google.com/spreadsheets/d/13gLhBRmXqtZu4EBsfG-Jq9vD32EhqQzGTKOQlgkpb4U/edit?usp=sharing

### 実装内容・手法
 ・qustionがnilかどうかの記述追加。
・また有効にするをチェックオフにした場合、question.idに対応するanswer.idに違いが発生しており、意図していない質問が削除状態になっている症状があったため、有効状態のanswerデータを取得するようeditアクションに追記しております。
　この実装により有効ではない質問は画面表示されないようにしたことから、ビューの記述も有効ではない質問は表示しない記述に変更しております。

### gemfileの変更
- [x] なし
- [ ] あり 
