### PR TITLE
検索ﾋｯﾄ無しのﾌﾗｯｼｭﾒｯｾｰｼﾞが5秒で消える処理追加

### DIFF
--- a/app/controllers/projects/counselings_controller.rb
+++ b/app/controllers/projects/counselings_controller.rb
@@ -297,7 +297,7 @@ class Projects::CounselingsController < Projects::BaseProjectController
     @you_addressee_counselings = @counselings = Counseling.none
     session[:you_addressee_counseling_ids] = []
     session[:all_counseling_ids] = []
-    flash[:danger] = '検索結果が見つかりませんでした。'
+    flash.now[:danger] = '検索結果が見つかりませんでした。'
   end
 
   # 相談検索(相談履歴)

--- a/app/views/projects/counselings/index.js.erb
+++ b/app/views/projects/counselings/index.js.erb
@@ -1,5 +1,10 @@
 <% if flash.now[:danger] %>
   $("#flash-messages").html('<div class="alert alert-danger"><%= j flash.now[:danger] %></div>');
+  setTimeout(function() {
+    $(".alert-danger").hide("fast", function() { // フラッシュメッセージを非表示
+      $(this).remove(); // 非表示後に要素をDOMから削除
+    });
+  }, 5000); // 5000ミリ秒（5秒）後に非表示
 <% end %>
 
 $("#you-addressee-counselings-container").html("<%= escape_javascript(render partial: 'projects/counselings/you_addressee_counselings', locals: { messages: @you_addressee_counselings }) %>");


### PR DESCRIPTION
### 概要
相談一覧画面で、検索ヒット無しのフラッシュメッセージが5秒経過で消える処理を追加

### タスク
- [ ] なし
- [x] あり _(タスクのリンクがあれば貼る)_
アプリ問題表34：「相談一覧、検索結果なしのフラッシュメッセージが消えない」
https://docs.google.com/spreadsheets/d/1qitHpAxSv65lzMyIFgvnDUr-YLbd484bAfxjEI1SDeo/edit?gid=0#gid=0&range=A35

### 実装内容・手法
①counselings/index.js.erb に、setTimeoutメソッドを追加し、5秒後にフラッシュメッセージが非表示になるように設定。
②フラッシュメッセージが消えることを確認後、相談一覧を再表示するとフラッシュメッセージが表示されていた為、
couselings_controller.rb のhandle_no_resultsメソッド(296～301行目)内の
flash[:danger] を flash.now[danger] に変更。

### 実装画像などあれば添付する

### gemfileの変更
- [x] なし
- [ ] あり 
