### PR TITLE
問題表47:プロジェクト報告回数の上限設定(31日まで)

### DIFF
--- a/app/assets/stylesheets/project.scss
+++ b/app/assets/stylesheets/project.scss
@@ -16,7 +16,7 @@
 }
 
 .box-number {
-  width: 50px;
+  width: 60px;
 }
 
 .box-week {

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -19,7 +19,7 @@ class Project < ApplicationRecord
   validates :name, presence: true, length: { maximum: 20 }
   validates :description, presence: true, length: { maximum: 200 }
   validates :leader_id, presence: true
-  validates :report_frequency, presence: true
+  validates :report_frequency, presence: true, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 31 }
   validates :next_report_date, presence: true
   validates :reported_flag, inclusion: [true, false]
 

--- a/app/views/projects/projects/_day_form.html.erb
+++ b/app/views/projects/projects/_day_form.html.erb
@@ -22,7 +22,7 @@
     <div class="project-detail">
       <%= f.label :report_frequency, "報告回数" %><span class="pl-2 font-weight-bold text-danger">必須</span>
       <div class="d-flex project-report-frequency">
-        <%= f.number_field :report_frequency, min: 1, class: "form-control box-number form-color", id: "report_frequency", required: true %>
+        <%= f.number_field :report_frequency, min: 1, max: 31, class: "form-control box-number form-color", id: "report_frequency", required: true %>
         <div>日に1回</div>
       </div>
     </div>

--- a/app/views/projects/projects/_edit_day_form.html.erb
+++ b/app/views/projects/projects/_edit_day_form.html.erb
@@ -21,7 +21,7 @@
     <div class="project-detail">
       <%= f.label :report_frequency, "報告回数" %><span class="pl-2 font-weight-bold text-danger">必須</span>
       <div class="d-flex project-report-frequency">
-        <%= f.number_field :report_frequency, min: 1, class: "form-control box-number form-color", id: "report_frequency", required: true %>
+        <%= f.number_field :report_frequency, min: 1,max: 31, class: "form-control box-number form-color", id: "report_frequency", required: true %>
         <div>日に1回</div>
       </div>
     </div>

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe "Projectモデルのテスト", type: :model do
       it "report_frequencyがなければ登録できない" do
         expect(build(:project, report_frequency: nil)).to be_invalid
       end
+      it "report_frequencyが1未満は登録できない" do
+        expect(build(:project, report_frequency: 0)).to be_invalid
+      end
+      it "report_frequencyが1以上は登録できる" do
+        expect(build(:project, report_frequency: 1)).to be_valid
+      end
+      it "report_frequencyが31以下は登録できる" do
+        expect(build(:project, report_frequency: 31)).to be_valid
+      end
+      it "report_frequencyが32以上は登録できない" do
+        expect(build(:project, report_frequency: 32)).to be_invalid
+      end
     end
     context "next_report_date(次回報告日)" do
       it "next_report_dateがなければ登録できない" do


### PR DESCRIPTION
プロジェクト報告回数のフォーマット調整

### 概要
問題表47の不具合対応としてプロジェクト報告回数の上限31日までに設定を行う。

### タスク
- [x] なし
- [ ] あり _(タスクのリンクがあれば貼る)_

### 実装内容・手法
報告回数のフォーマット調整
数字２桁を表示されるように修正を行った。
プロジェクト報告回数の上限設定(31日まで)
プロジェクト編集画面とプロジェクト作成画面に反映。
またプロジェクト報告回数のモデルについて上限下限のバリテーションを設定した。

### gemfileの変更
- [x] なし
- [ ] あり 
