### PR TITLE
問題表52　ログアウト後、ブラウザバックでメンバー一覧画面に戻って、アクション列を操作するとエラー  修正完了

### DIFF
--- a/.rubocop_todo1.yml
+++ b/.rubocop_todo1.yml
@@ -123,6 +123,7 @@ Rails/HelperInstanceVariable:
 # Offense count: 43
 Rails/I18nLocaleTexts:
   Exclude:
+    - 'app/controllers/application_controller.rb'
     - 'app/controllers/admin_users/admin_user_base_controller.rb'
     - 'app/controllers/formats/base_format_controller.rb'
     - 'app/controllers/formats/report_formats_controller.rb'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::Base
+  rescue_from ActionController::InvalidAuthenticityToken do |exception|
+    redirect_to new_user_session_path, alert: 'セッションが切れました。再度ログインしてください。'
+  end
+
   before_action :store_user_location!, if: :storable_location?
   before_action :reset_flash_message_displayed
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  rescue_from ActionController::InvalidAuthenticityToken do |exception|
+  rescue_from ActionController::InvalidAuthenticityToken do |_exception|
     redirect_to new_user_session_path, alert: 'セッションが切れました。再度ログインしてください。'
   end
 

--- a/app/controllers/formats/base_format_controller.rb
+++ b/app/controllers/formats/base_format_controller.rb
@@ -1,4 +1,5 @@
 class Formats::BaseFormatController < BaseController
+  before_action :authenticate_user!
   before_action :project_leader_user
 
   private

--- a/app/controllers/projects/members_controller.rb
+++ b/app/controllers/projects/members_controller.rb
@@ -2,7 +2,7 @@ class Projects::MembersController < Projects::BaseProjectController
   skip_before_action :correct_user, only: %i[join]
   before_action :project_authorization, only: %i[index destroy delegate cancel_delegate send_reminder reset_reminder]
   before_action :admin_user, only: %i[setting set_admin]
-  # before_action :project_leader_user, only: %i[index]
+  before_action :project_leader_user, only: %i[destroy delegate cancel_delegate]
 
   # プロジェクトへの参加アクション（招待メールに張付リンククリック時アクション）
   def join
@@ -41,7 +41,7 @@ class Projects::MembersController < Projects::BaseProjectController
     end
   end
 
-  # プロジェクトメンバーをプロジェクトの集計から外す
+  # プロジェクトメンバーをプロジェクトから外す
   def destroy
     user = User.find(params[:member_id])
     project = Project.find(params[:project_id])

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -2,6 +2,7 @@ class Users::InvitationsController < BaseController
   # before_action :get_user,         only: [:edit, :update]
   # before_action :valid_user,       only: [:edit, :update]
   # before_action :check_expiration, only: [:edit, :update]
+  before_action :authenticate_user!
   before_action :project_leader_user
 
   def new


### PR DESCRIPTION
### 概要
問題表52 の不具合対応
_([ho-ren-soアプリ問題表：無効な権限によるエラー](https://docs.google.com/spreadsheets/d/1qitHpAxSv65lzMyIFgvnDUr-YLbd484bAfxjEI1SDeo/edit?gid=250252245#gid=250252245))_

### タスク
- [ ] なし
- [x] あり _([ガントチャート](https://docs.google.com/spreadsheets/d/1wq_WEzyd21T2tE9G9uPtkuF1HJoNRV3wfVxFOZlnuEE/edit?gid=1058469562#gid=1058469562&range=B135))_

### 実装内容・手法
・セッション切れのエラー（ActionController::InvalidAuthenticityToken）発生時に、ログイン画面にリダイレクトする処理を追加。
・ membersコントローラーの以下のアクションは、リーダー権限でのみ実行可能となるよう修正。
    - destroy（プロジェクトからメンバーを外す）
    - delegate（リーダ権限委任リクエスト）
    - cancel_delegate（リーダー権限委任のキャンセル）   
・以下の処理について、ログインしていないユーザーを弾くよう、before_actionに認証チェック処理を追加。
    - プロジェクトへのメンバー招待処理（Invitationsコントローラ）
    - 報告フォーマット編集処理（report_formatsコントローラ）

### gemfileの変更
- [x] なし
- [ ] あり 
